### PR TITLE
WIP: support unwrapping

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,3 +211,9 @@ end
     @test (mt |> columntable) == (a = Real[1, 2.0, 3], c = ["7", "8", "9"])
     @test length(mt |> rowtable) == 3
 end
+
+@testset "nesting" begin
+    x = (a = (b = 1,), c = 2)
+    @test Tables.columns([x]) == (a = [(b = 1,)], c = [2])
+    @test Tables.columns([x], unwrap = T -> T <: NamedTuple) == (a = (b = [1,],), c = [2])
+end


### PR DESCRIPTION
This is an attempt at addressing #13. It is still WIP (I've only done the case with known schema, haven't added tests and have probably forgotten to added the `unwrap` keyword in a few places) and lacks tests but I hope is good enough to give an idea. It works as follows:

the user passes a `unwrap` optional argument (defaults to `t -> false`) that specifies what types should be unwrapped. So the default behavior is unchanged:

```julia
julia> x = [(a=(b=1,), c=2)]
1-element Array{NamedTuple{(:a, :c),Tuple{NamedTuple{(:b,),Tuple{Int64}},Int64}},1}:
 (a = (b = 1,), c = 2)

julia> Tables.columns(x)
(a = NamedTuple{(:b,),Tuple{Int64}}[(b = 1,)], c = [2])

julia> unwrap(x) = false
unwrap (generic function with 1 method)

julia> unwrap(::Type{<:NamedTuple}) = true
unwrap (generic function with 2 methods)

julia> Tables.columns(x, unwrap=unwrap)
(a = (b = [1],), c = [2])
```

From experimentation in StructArrays the compiler is quite good here so it figures out the value of `unwrap(T)` in advance (at least in general I couldn't find traces of `unwrap` in `@code_llvm` and results were inferred correctly).

In #13 I was wrong: there's actually no need to add extra `setindex!` or `push!` method provided one is a bit careful in the definition of `add!`
