### PR TITLE
Fix datavaluetype function

### DIFF
--- a/src/datavalues.jl
+++ b/src/datavalues.jl
@@ -5,6 +5,7 @@ nondatavaluetype(::Type{DataValue{T}}) where {T} = Union{T, Missing}
 unwrap(x::DataValue) = isna(x) ? missing : DataValues.unsafe_get(x)
 datavaluetype(::Type{T}) where {T <: DataValue} = T
 datavaluetype(::Type{Union{T, Missing}}) where {T} = DataValue{T}
+datavaluetype(::Type{Missing}) = DataValue{Union{}}
 
 struct DataValueRowIterator{NT, S}
     x::S

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,4 +214,8 @@ end
     mt = Tables.DataValueUnwrapper(ei.x |> y->QueryOperators.map(y, x->(a=x.a, c=x.c), Expr(:block)))
     @test (mt |> columntable) == (a = Real[1, 2.0, 3], c = ["7", "8", "9"])
     @test length(mt |> rowtable) == 3
+
+    rt = (a = Missing[missing, missing], b=[1,2])
+    dv = Tables.datavaluerows(rt)
+    @test eltype(dv) == NamedTuple{(:a, :b), Tuple{DataValue{Union{}}, Int}}
 end


### PR DESCRIPTION
Fixes https://github.com/queryverse/Query.jl/issues/205.

It also seems like the tests for the Queryverse integration don't run in a normal test run? Could that be changed? Not running them seems quite brittle...