### PR TITLE
Allow collection of higher-dimensional containers by buildcolumns

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -56,7 +56,7 @@ allocatecolumn(T, len) = Vector{T}(undef, len)
 end
 
 # add! will push! or setindex! a value depending on if the row-iterator HasLength or not
-@inline add!(val, col::Int, nm::Symbol, ::Union{Base.HasLength, Base.HasShape{1}}, nt, row) = setindex!(nt[col], val, row)
+@inline add!(val, col::Int, nm::Symbol, ::Union{Base.HasLength, Base.HasShape}, nt, row) = setindex!(nt[col], val, row)
 @inline add!(val, col::Int, nm::Symbol, T, nt, row) = push!(nt[col], val)
 
 @inline function buildcolumns(schema, rowitr::T) where {T}
@@ -69,10 +69,10 @@ end
     return nt
 end
 
-@inline add!(dest::AbstractVector, val, ::Union{Base.HasLength, Base.HasShape{1}}, row) = setindex!(dest, val, row)
-@inline add!(dest::AbstractVector, val, T, row) = push!(dest, val)
+@inline add!(dest::AbstractArray, val, ::Union{Base.HasLength, Base.HasShape}, row) = setindex!(dest, val, row)
+@inline add!(dest::AbstractArray, val, T, row) = push!(dest, val)
 
-@inline function add_or_widen!(dest::AbstractVector{T}, val::S, nm::Symbol, L, row, len, updated) where {T, S}
+@inline function add_or_widen!(dest::AbstractArray{T}, val::S, nm::Symbol, L, row, len, updated) where {T, S}
     if S === T || promote_type(S, T) <: T
         add!(dest, val, L, row)
         return dest

--- a/src/namedtuples.jl
+++ b/src/namedtuples.jl
@@ -65,8 +65,8 @@ function rowtable(rt::RowTable, itr::T) where {T}
     return append!(rt, namedtupleiterator(eltype(r), r))
 end
 
-# NamedTuple of Vectors
-const ColumnTable = NamedTuple{names, T} where {names, T <: NTuple{N, AbstractVector{S} where S}} where {N}
+# NamedTuple of arrays of matching dimensionality
+const ColumnTable = NamedTuple{names, T} where {names, T <: NTuple{N, AbstractArray{S, D} where S}} where {N, D}
 rowcount(c::ColumnTable) = length(c) == 0 ? 0 : length(c[1])
 
 # interface implementation


### PR DESCRIPTION
First attempt at to fix #37 

Combined with #31, I can now build `TypedTables.Table`s out of `Generators` involving more than one input. E.g `Table(merge(row1, row2) for row1 in table1, row2 in table2)` (and I particularly enjoyed the inner join `Table(merge(row1, row2) for row1 in table1, row2 in table2 if predicate(row1, row2))`!).