### PR TITLE
make rowiterator an abstractvector

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -48,6 +48,7 @@ struct RowIterator{T, U} <: AbstractVector{U}
 end
 Base.size(x::RowIterator) = (x.len,)
 Base.getindex(x::RowIterator, i::Int) = ColumnsRow(x.columns, i)
+Base.IndexStyle(::Type{<:RowIterator}) = IndexLinear()
 schema(x::RowIterator) = schema(x.columns)
 
 function rows(x::T) where {T}

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -41,18 +41,14 @@ end
     Expr(:block, exprs...)
 end
 
-struct RowIterator{T}
+struct RowIterator{T, U} <: AbstractVector{U}
     columns::T
     len::Int
+    RowIterator(columns::T, len::Int) where {T} = new{T, ColumnsRow{T}}(columns, len)
 end
-Base.eltype(x::RowIterator{T}) where {T} = ColumnsRow{T}
-Base.length(x::RowIterator) = x.len
+Base.size(x::RowIterator) = (x.len,)
+Base.getindex(x::RowIterator, i::Int) = ColumnsRow(x.columns, i)
 schema(x::RowIterator) = schema(x.columns)
-
-function Base.iterate(rows::RowIterator, st=1)
-    st > length(rows) && return nothing
-    return ColumnsRow(rows.columns, st), st + 1
-end
 
 function rows(x::T) where {T}
     if columnaccess(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,6 +223,17 @@ end
     @test sortperm([a, b, c, d]) == [3, 1, 2, 4]
 end
 
+@testset "rowiterator array" begin
+    t = (x = [1, 1, 0, 2], y = [-1, 1, 3, 2])
+    rt = Tables.rows(t)
+    @test rt isa AbstractArray
+    @test length(rt) == 4
+    @test Base.IndexStyle(rt) == IndexLinear()
+    @test Base.IndexStyle(typeof(rt)) == IndexLinear()
+    @test rt[3].x == 0
+    @test rt[3].y == 3
+end
+
 @static if :Query in Symbol.(Base.loaded_modules_array())
     rt = (a = Real[1, 2.0, 3], b = Union{Missing, Float64}[4.0, missing, 6.0], c = ["7", "8", "9"])
 


### PR DESCRIPTION
This I think simplifies the code and adds feature as we can use the `AbstractVector` machinery to iterate and get an element by index / slice the table etc...