### PR TITLE
Patch to make 0.13 usable

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.7
 Requires
+TableTraits
+IteratorInterfaceExtensions


### PR DESCRIPTION
Should fix the
```
ERROR: LoadError: ArgumentError: Package Tables does not have TableTraits in its dependencies:
- If you have Tables checked out for development and have
  added TableTraits as a dependency but haven't updated your primary
  environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with Tables
```