### PR TITLE
Use StringVector(undef, dim) constructor

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -20,8 +20,9 @@ function __init__()
     end
     @require WeakRefStrings="ea10d353-3f73-51f8-a26c-33c1cb351aa5" begin
         using .WeakRefStrings
-        allocatecolumn(::Type{WeakRefString{T}}, rows) where {T} = StringVector(rows)
-        allocatecolumn(::Type{Union{Missing, WeakRefString{T}}}, rows) where {T} = StringVector{Union{Missing, String}}(rows)
+        allocatecolumn(::Type{WeakRefString{T}}, rows) where {T} = StringVector(undef, rows)
+        allocatecolumn(::Type{Union{Missing, WeakRefString{T}}}, rows) where {T} =
+            StringVector{Union{Missing, String}}(undef, rows)
         unweakref(wk::WeakRefString) = string(wk)
         unweakreftype(::Type{<:WeakRefString}) = String
     end


### PR DESCRIPTION
The other one has been removed from WeakRefStrings 0.5.4 (https://github.com/JuliaData/WeakRefStrings.jl/pull/52).

Unfortunately I don't know if we can mark somewhere that we now require version 0.5.4, since this is an optional dependency.