### PR TITLE
Avoid intermediate copy of table for TableTraits sources

### DIFF
--- a/src/datavalues.jl
+++ b/src/datavalues.jl
@@ -24,8 +24,10 @@ DataValueRowIterator(::Type{NT}, x::S) where {NT <: NamedTuple, S} = DataValueRo
 DataValueRowIterator(::Type{Schema{names, types}}, x::S) where {names, types, S} = DataValueRowIterator{datavaluetype(NamedTuple{names, types}), S}(x)
 
 function datavaluerows(x)
-    r = Tables.rowtable(x)
-    return DataValueRowIterator(datavaluetype(Tables.schema(r)), r)
+    r = Tables.rows(x)
+    s = Tables.schema(r)
+    s === nothing && error("Schemaless sources cannot be passed to datavaluerows.")
+    return DataValueRowIterator(datavaluetype(s), r)
 end
 
 _iteratorsize(x) = x


### PR DESCRIPTION
#60 introduced a change that lead to a quite significant performance regression for the DataFrames.jl/Query.jl combination: whenever one queried a `DataFrame`, Tables.jl would now first make a copy of the entire content of the `DataFrame` into a vector of `NamedTuple`s, and then that was passed on to Query. This PR undoes that.

Performance on `master`:
```julia
julia> using DataFrames, Query, BenchmarkTools
                                                           
julia> n = 1_000_000                                       
1000000                                                    
                                                           
julia> df = DataFrame(a=rand(n), b=rand(n), c=rand(n));    
                                                           
julia> @benchmark DataFrame($df |> @map(_))                
BenchmarkTools.Trial:                                      
  memory estimate:  183.11 MiB                             
  allocs estimate:  6000074                                
  --------------                                           
  minimum time:     151.181 ms (44.13% GC)                 
  median time:      153.330 ms (44.11% GC)                 
  mean time:        156.053 ms (44.50% GC)                 
  maximum time:     228.749 ms (52.04% GC)                 
  --------------                                           
  samples:          33                                     
  evals/sample:     1          
```
With my PR:
```julia
julia> @benchmark DataFrame($df |> @map(_))
BenchmarkTools.Trial:
  memory estimate:  160.22 MiB
  allocs estimate:  6000071
  --------------
  minimum time:     83.083 ms (9.75% GC)
  median time:      122.114 ms (31.11% GC)
  mean time:        120.394 ms (32.12% GC)
  maximum time:     162.952 ms (46.85% GC)
  --------------
  samples:          42
  evals/sample:     1
```
@quinnj wrote [here](https://github.com/JuliaData/Tables.jl/pull/60/files#r255115630) that the change on `master` was intentional and fixed some scenario. I don't fully understand that scenario (i.e. I don't understand what source we have that would use Tables to implement the TableTraits interface *and* not have a schema), but I generally don't understand much of the code here in Tables.jl, so this PR here might well cause some other trouble that I didn't see coming :)