### PR TITLE
Run TableTraits integration tests by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,3 +9,11 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"
+QueryOperators = "2aef5ad7-51ca-5a8f-8e88-e75cf067b44b"
+
+[targets]
+test = ["Test", "DataValues", "QueryOperators"]

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+QueryOperators
+DataValues

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Tables, TableTraits
+using Test, Tables, TableTraits, DataValues, QueryOperators
 
 @testset "utils.jl" begin
 
@@ -353,7 +353,7 @@ table = ctable |> Tables.select(:C, :A) |> Tables.rowtable
 @test isequal(ctable[1], map(x->x[2], table))
 end
 
-@static if :Query in Symbol.(Base.loaded_modules_array())
+@testset "TableTraits integration" begin
     rt = (a = Real[1, 2.0, 3], b = Union{Missing, Float64}[4.0, missing, 6.0], c = ["7", "8", "9"])
 
     dv = Tables.datavaluerows(rt)


### PR DESCRIPTION
I think they really should run during travis and appveyor runs.