### PR TITLE
Remove using IteratorInterfaceExtensions

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -2,7 +2,7 @@ module Tables
 
 using Requires, LinearAlgebra
 
-using TableTraits, IteratorInterfaceExtensions
+using TableTraits
 
 export rowtable, columntable
 


### PR DESCRIPTION
It's already done inside `@require` and it breaks package compilation.

Fixes https://github.com/JuliaData/Tables.jl/issues/70.