### PR TITLE
Fix https://github.com/JuliaData/DataFrames.jl/issues/1734. The issue…

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -150,7 +150,8 @@ end
     elseif TableTraits.supports_get_columns_copy_using_missing(x)
         return TableTraits.get_columns_copy_using_missing(x)
     elseif istable(x)
-        return columns(IteratorWrapper(IteratorInterfaceExtensions.getiterator(x)))
+        iw = IteratorWrapper(IteratorInterfaceExtensions.getiterator(x))
+        return buildcolumns(schema(iw), iw)
     end
     throw(ArgumentError("no default `Tables.columns` implementation for type: $T"))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,6 +24,7 @@ end
 
 # generic fallback from getproperty w/ type information to basic symbol lookup
 Base.getproperty(x, ::Type{T}, i::Int, nm::Symbol) where {T} = getproperty(x, nm)
+Base.getproperty(x::NamedTuple{names, types}, ::Type{T}, i::Int, nm::Symbol) where {names, types, T} = Core.getfield(x, i)
 
 """
     Tables.eachcolumn(f, sch, row, args...)


### PR DESCRIPTION
… here, according to Keno, is the compiler can't quite optimize the getproperty w/ symbol => getfield w/ symbol on NamedTuples. Defining our own call to getfield w/ Int solves the issue by avoiding the symbol => index lookup. Long term, we should probably define our own getrowvalue function instead of overloading getproperty like we do, but we're doing it already, so we'll keep it in the short term. It actually saves us here because we have a way to intercept the `getproperty` call and call `getfield` directly.