### PR TITLE
Use TableTraits.isiterabletable in rows and columns

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -58,7 +58,7 @@ function rows(x::T) where {T}
     if columnaccess(T)
         cols = columns(x)
         return RowIterator(cols, rowcount(cols))
-    elseif Base.isiterable(T)
+    elseif TableTraits.isiterabletable(x) === true || Base.isiterable(T)
         return IteratorWrapper(IteratorInterfaceExtensions.getiterator(x))
     end
     throw(ArgumentError("no default `Tables.rows` implementation for type: $T"))
@@ -149,7 +149,7 @@ end
         return buildcolumns(schema(r), r)
     elseif TableTraits.supports_get_columns_copy_using_missing(x)
         return TableTraits.get_columns_copy_using_missing(x)
-    elseif Base.isiterable(T)
+    elseif TableTraits.isiterabletable(x) === true || Base.isiterable(T)
         iw = IteratorWrapper(IteratorInterfaceExtensions.getiterator(x))
         return buildcolumns(schema(iw), iw)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Tables, TableTraits, DataValues, QueryOperators
+using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceExtensions
 
 @testset "utils.jl" begin
 
@@ -259,6 +259,19 @@ end
 
 let x=ColumnSource()
     @test Tables.columns(x) == TableTraits.get_columns_copy_using_missing(x)
+end
+
+struct ColumnSource2
+end
+
+IteratorInterfaceExtensions.isiterable(x::ColumnSource2) = true
+TableTraits.isiterabletable(::ColumnSource2) = true
+
+IteratorInterfaceExtensions.getiterator(::ColumnSource2) =
+    Tables.rows((a=[1,2,3], b=[4.,5.,6.], c=["A", "B", "C"]))
+
+let x=ColumnSource2()
+    @test Tables.columns(x) == (a=[1,2,3], b=[4.,5.,6.], c=["A", "B", "C"])
 end
 
 @testset "operations.jl" begin


### PR DESCRIPTION
Otherwise we misdetect some table types which do not define `Base.iterable`, like `ExcelFile`.
Add a new test for this pattern.

Fixes https://github.com/queryverse/ExcelFiles.jl/issues/33, which appeared after https://github.com/JuliaData/Tables.jl/pull/84.

CI fails due to version incompatibilities, not sure why (EDIT: that's https://github.com/JuliaData/Tables.jl/issues/88).