### PR TITLE
Simplify the fallback logic a bit while ensuring any object that is I…

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -58,7 +58,7 @@ function rows(x::T) where {T}
     if columnaccess(T)
         cols = columns(x)
         return RowIterator(cols, rowcount(cols))
-    elseif TableTraits.isiterabletable(x) === true || Base.isiterable(T)
+    elseif IteratorInterfaceExtensions.isiterable(x)
         return IteratorWrapper(IteratorInterfaceExtensions.getiterator(x))
     end
     throw(ArgumentError("no default `Tables.rows` implementation for type: $T"))
@@ -149,7 +149,7 @@ end
         return buildcolumns(schema(r), r)
     elseif TableTraits.supports_get_columns_copy_using_missing(x)
         return TableTraits.get_columns_copy_using_missing(x)
-    elseif TableTraits.isiterabletable(x) === true || Base.isiterable(T)
+    elseif IteratorInterfaceExtensions.isiterable(x)
         iw = IteratorWrapper(IteratorInterfaceExtensions.getiterator(x))
         return buildcolumns(schema(iw), iw)
     end


### PR DESCRIPTION
…teratorInterfaceExtensions.isiterable is allowed to be iterated. Should fix https://github.com/JuliaData/DataFrames.jl/issues/1780