### PR TITLE
Add a new CopiedColumns wrapper struct to signal to downstream sinks …

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -154,7 +154,7 @@ columns(x::CopiedColumns) = x
 schema(x::CopiedColumns) = schema(source(x))
 materializer(x::CopiedColumns) = materializer(source(x))
 Base.propertynames(x::CopiedColumns) = propertynames(source(x))
-Base.getproperty(x::CopiedColumns, nm) = getproperty(source(x), nm)
+Base.getproperty(x::CopiedColumns, nm::Symbol) = getproperty(source(x), nm)
 
 @inline function columns(x::T) where {T}
     if rowaccess(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,7 +258,7 @@ function TableTraits.get_columns_copy_using_missing(x::ColumnSource)
 end
 
 let x=ColumnSource()
-    @test Tables.columns(x) == TableTraits.get_columns_copy_using_missing(x)
+    @test Tables.source(Tables.columns(x)) == Tables.source(Tables.CopiedColumns(TableTraits.get_columns_copy_using_missing(x)))
 end
 
 struct ColumnSource2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,7 +271,7 @@ IteratorInterfaceExtensions.getiterator(::ColumnSource2) =
     Tables.rows((a=[1,2,3], b=[4.,5.,6.], c=["A", "B", "C"]))
 
 let x=ColumnSource2()
-    @test Tables.columns(x) == (a=[1,2,3], b=[4.,5.,6.], c=["A", "B", "C"])
+    @test Tables.source(Tables.columns(x)) == (a=[1,2,3], b=[4.,5.,6.], c=["A", "B", "C"])
 end
 
 @testset "operations.jl" begin


### PR DESCRIPTION
…that the columns source columns have been generated/copied already, to avoid unnecessary copies in sink functions themselves. Addresses https://github.com/JuliaData/DataFrames.jl/issues/1809

cc: @davidanthoff, @nalimilan, @bkamins 