### PR TITLE
support julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"
 QueryOperators = "2aef5ad7-51ca-5a8f-8e88-e75cf067b44b"
 
 [compat]
-julia = "1"
+julia = "0.7, 1"
 IteratorInterfaceExtensions = "0.1.1, 1"
 TableTraits = "0.4.1, 1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+  - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: 1.1
   - julia_version: nightly


### PR DESCRIPTION
this should work once https://github.com/queryverse/IteratorInterfaceExtensions.jl/pull/3 get's merged and tagged, and is needed for DataFrames to continue to support julia 0.7. see https://github.com/JuliaData/DataFrames.jl/pull/1784#issuecomment-493694454.  i know not everyone thinks that that is useful, but i do, and since the effort involved is so trivial, i'm happy to take in on myself.