### PR TITLE
Make sure we account for DataValue{Any}, which doesn't quite fit in t…

### DIFF
--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -19,7 +19,7 @@ Tables.rowaccess(::Type{<:IteratorWrapper}) = true
 Tables.rows(x::IteratorWrapper) = x
 
 function Tables.schema(dv::IteratorWrapper{S}) where {S}
-    eT = eltype(S)
+    eT = eltype(dv.x)
     (!(eT <: NamedTuple) || eT === Union{}) && return schema(dv.x)
     return Tables.Schema(nondatavaluenamedtuple(eT))
 end
@@ -52,17 +52,26 @@ struct IteratorRow{T}
     row::T
 end
 
+unwrap(::Type{T}, x) where {T} = convert(T, x)
+unwrap(::Type{Any}, x) = x.hasvalue ? x.value : missing
+
 function Base.getproperty(d::IteratorRow, ::Type{T}, col::Int, nm) where {T}
     x = getproperty(getfield(d, 1), T, col, nm)
-    return convert(DataValueInterfaces.nondatavaluetype(typeof(x)), x)
+    TT = typeof(x)
+    TTT = DataValueInterfaces.nondatavaluetype(TT)
+    return TT == TTT ? x : unwrap(TTT, x)
 end
 function Base.getproperty(d::IteratorRow, nm::Symbol)
     x = getproperty(getfield(d, 1), nm)
-    return convert(DataValueInterfaces.nondatavaluetype(typeof(x)), x)
+    TT = typeof(x)
+    TTT = DataValueInterfaces.nondatavaluetype(TT)
+    return TT == TTT ? x : unwrap(TTT, x)
 end
 function Base.getproperty(d::IteratorRow, nm::Int)
     x = getproperty(getfield(d, 1), nm)
-    return convert(DataValueInterfaces.nondatavaluetype(typeof(x)), x)
+    TT = typeof(x)
+    TTT = DataValueInterfaces.nondatavaluetype(TT)
+    return TT == TTT ? x : unwrap(TTT, x)
 end
 Base.propertynames(d::IteratorRow) = propertynames(getfield(d, 1))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -589,4 +589,7 @@ end
     rt = (a = Missing[missing, missing], b=[1,2])
     dv = Tables.datavaluerows(rt)
     @test eltype(dv) == NamedTuple{(:a, :b), Tuple{DataValue{Union{}}, Int}}
+
+    # DataValue{Any}
+    @test isequal(Tables.columntable(Tables.nondatavaluerows([(a=DataValue{Any}(), b=DataValue{Int}())])), (a = Any[missing], b = Union{Missing, Int64}[missing]))
 end


### PR DESCRIPTION
…he normal convert-to-nondatavaluetype paradigm. Here, we call nondatavaluetype, and if the result is a different type, we know the value we're dealing w/ is a DataValue. We then call a new method, unwrap, if it's a DataValue, which has a special overload for Any. If it's not a DataValue type, no conversion is needed. Fixes #109

cc: @davidanthoff @nalimilan 

I think this is a pretty good solution that is still compiler-friendly (i.e. the non-DataValue case will be optimized away)