### PR TITLE
Add rename and rename! to Tables.jl API

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -130,3 +130,6 @@ end
     row, st = state
     return SelectRow{typeof(row), names}(row), st
 end
+
+function rename end
+function rename! end


### PR DESCRIPTION
Following https://github.com/JuliaData/DataFrames.jl/issues/1514#issuecomment-527935887.

The open question is if we want both `rename` and `rename!` in the common API (`rename` is probably more universally needed, `rename!` is applicable in DataFrames.jl but not in contexts where table does not allow changing column names in-place). I propose to have both but please comment (`rename!` can also live in DataFrames.jl only otherwise)

CC @piever - for syncing with JuliaDB.jl.