### PR TITLE
Improve inferrability of IteratorRow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ DataValueInterfaces = "e2d170a0-9d28-54be-80f0-106bbe20a464"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"
 QueryOperators = "2aef5ad7-51ca-5a8f-8e88-e75cf067b44b"
 
@@ -22,4 +23,4 @@ IteratorInterfaceExtensions = "0.1.1, 1"
 TableTraits = "0.4.1, 1"
 
 [targets]
-test = ["Test", "DataValues", "QueryOperators"]
+test = ["Test", "Compat", "DataValues", "QueryOperators"]

--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -75,6 +75,14 @@ function Base.getproperty(d::IteratorRow, nm::Int)
 end
 Base.propertynames(d::IteratorRow) = propertynames(getfield(d, 1))
 
+function Base.propertynames(d::IteratorRow{<:NamedTuple{names}}) where {names}
+    if @isdefined(names)
+        return names
+    else
+        return propertynames(getfield(d, 1))
+    end
+end
+
 # DataValueRowIterator wraps a Row iterator and will wrap `Union{T, Missing}` typed fields in DataValues
 struct DataValueRowIterator{NT, S}
     x::S

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceExtensions
+using Compat: hasproperty
 
 @testset "utils.jl" begin
 
@@ -614,4 +615,12 @@ end
 
     # DataValue{Any}
     @test isequal(Tables.columntable(Tables.nondatavaluerows([(a=DataValue{Any}(), b=DataValue{Int}())])), (a = Any[missing], b = Union{Missing, Int64}[missing]))
+
+    # Inferrability of IteratorRow
+    has_a(row) = Val(hasproperty(row, :a))
+    @test (@inferred has_a(Tables.IteratorRow((a = 1,)))) === Val(true)
+    @test (@inferred has_a(Tables.IteratorRow((b = 1,)))) === Val(false)
+    # Don't panic even in a pathological case:
+    @test has_a(Tables.IteratorRow{NamedTuple}((a = 1,))) === Val(true)
+    @test has_a(Tables.IteratorRow{NamedTuple}((b = 1,))) === Val(false)
 end


### PR DESCRIPTION
This PR makes `hasproperty(IteratorRow((a = 1,)), :a)` inferable.