### PR TITLE
Add Tables interface to RowIterator

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -52,6 +52,12 @@ struct RowIterator{T}
 end
 Base.eltype(x::RowIterator{T}) where {T} = ColumnsRow{T}
 Base.length(x::RowIterator) = x.len
+istable(::Type{<:RowIterator}) = true
+rowaccess(::Type{<:RowIterator}) = true
+rows(x::RowIterator) = x
+columnaccess(::Type{<:RowIterator{T}}) where T = columnaccess(T)
+columns(x::RowIterator) = x.columns
+materializer(x::RowIterator) = materializer(x.columns)
 schema(x::RowIterator) = schema(x.columns)
 
 function Base.iterate(rows::RowIterator, st=1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,12 @@ using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceEx
     @test Tables.schema(rows) == Tables.Schema((:a, :b), (Int, Int))
     row = first(rows)
     @test row.a == 1
+    @test Tables.istable(rows)
+    @test Tables.rowaccess(rows)
+    @test Tables.rows(rows) === rows
+    @test Tables.columnaccess(rows)
+    @test Tables.columns(rows) === nt
+    @test Tables.materializer(rows) === Tables.materializer(nt)
 
     @test Tables.sym(1) === 1
     @test Tables.sym("hey") == :hey


### PR DESCRIPTION
This PR turns `RowIterator` into a proper table.  It came up in https://github.com/JuliaData/TypedTables.jl/pull/57 to support semantically row-oriented `append!` with column-oriented memory access for optimization.  The idea is to use `append!(dest, Tables.row(src))` to declare that you are adding rows in `src` to `dest` even when `iterate(src)` is not defined for column-wise.  Example usage is: `append!(Table(a=[1], b=[2]), Tables.rows((a=[3], b=[4])))`.
