### PR TITLE
Idea: don't use types for documenting Row and Columns?

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -220,10 +220,31 @@ The interface to becoming a proper table is straightforward:
 
 Based on whether your table type has defined `Tables.rows` or `Tables.columns`, you then ensure that the `Row` iterator
 or `Columns` object satisfies the respective interface:
+
 ```@docs
-Tables.Row
 Tables.Columns
 ```
+
+### `Row`
+
+An interface type that represents a single row of a table, with column values retrievable by name or index.
+The high-level [`Tables.rows`](@ref) function returns a `Row`-compatible
+iterator from any input table source.
+
+Any object implements the `Row` interface, by satisfying the following:
+| Required Methods                                       | Default Definition        | Brief Description                                                                                                                                                |
+|--------------------------------------------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Tables.getcolumn(row, i::Int)`                        | getfield(row, i)          | Retrieve a column value by index                                                                                                                                 |
+| `Tables.getcolumn(row, nm::Symbol)`                    | getproperty(row, nm)      | Retrieve a column value by name                                                                                                                                  |
+| `Tables.columnnames(row)`                              | propertynames(row)        | Return column names for a row as an indexable collection                                                                                                         |
+| **Optional methods**                                   |                           |                                                                                                                                                                  |
+| `Tables.getcolumn(row, ::Type{T}, i::Int, nm::Symbol)` | Tables.getcolumn(row, nm) | Given a column type `T`, index `i`, and column name `nm`, retrieve the column value. Provides a type-stable or even constant-prop-able mechanism for efficiency. |
+
+Note that custom row types shouldn't subtype `Row`, as it is purely an interface type
+to help document the Tables.jl API. See the [`Tables.AbstractRow`](@ref) type
+for a type to potentially subtype to gain useful default behaviors.
+
+### Abstract `Row` and `Columns` types
 
 Though the strict requirements for `Row` and `Columns` are minimal (just `getcolumn` and `columnnames`), you may desire
 additional behavior for your row or columns types (and you're implementing them yourself). For convenience, Tables.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -221,10 +221,6 @@ The interface to becoming a proper table is straightforward:
 Based on whether your table type has defined `Tables.rows` or `Tables.columns`, you then ensure that the `Row` iterator
 or `Columns` object satisfies the respective interface:
 
-```@docs
-Tables.Columns
-```
-
 ### `Row`
 
 An interface type that represents a single row of a table, with column values retrievable by name or index.
@@ -242,6 +238,28 @@ Any object implements the `Row` interface, by satisfying the following:
 
 Note that custom row types shouldn't subtype `Row`, as it is purely an interface type
 to help document the Tables.jl API. See the [`Tables.AbstractRow`](@ref) type
+for a type to potentially subtype to gain useful default behaviors.
+
+### `Columns`
+
+An interface type defined as an ordered set of columns that support
+retrieval of individual columns by name or index. A retrieved column
+must be an indexable collection with known length, i.e. an object
+that supports `length(col)` and `col[i]` for any `i = 1:length(col)`.
+The high-level [`Tables.columns`](@ref) function returns a `Columns`-compatible
+object from any input table source.
+
+Any object implements the `Columns` interface, by satisfying the following:
+| Required Methods                                         | Default Definition          | Brief Description                                                                                                                                            |
+|----------------------------------------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Tables.getcolumn(table, i::Int)`                        | getfield(table, i)          | Retrieve a column by index                                                                                                                                   |
+| `Tables.getcolumn(table, nm::Symbol)`                    | getproperty(table, nm)      | Retrieve a column by name                                                                                                                                    |
+| `Tables.columnnames(table)`                              | propertynames(table)        | Return column names for a table as an indexable collection                                                                                                   |
+| **Optional methods**                                     |                             |                                                                                                                                                              |
+| `Tables.getcolumn(table, ::Type{T}, i::Int, nm::Symbol)` | Tables.getcolumn(table, nm) | Given a column eltype `T`, index `i`, and column name `nm`, retrieve the column. Provides a type-stable or even constant-prop-able mechanism for efficiency. |
+
+Note that table sources shouldn't subtype `Columns`, as it is purely an interface type
+to help document the Tables.jl API. See the [`Tables.AbstractColumns`](@ref) type
 for a type to potentially subtype to gain useful default behaviors.
 
 ### Abstract `Row` and `Columns` types

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -236,8 +236,7 @@ Any object implements the `Row` interface, by satisfying the following:
 | **Optional methods**                                   |                           |                                                                                                                                                                  |
 | `Tables.getcolumn(row, ::Type{T}, i::Int, nm::Symbol)` | Tables.getcolumn(row, nm) | Given a column type `T`, index `i`, and column name `nm`, retrieve the column value. Provides a type-stable or even constant-prop-able mechanism for efficiency. |
 
-Note that custom row types shouldn't subtype `Row`, as it is purely an interface type
-to help document the Tables.jl API. See the [`Tables.AbstractRow`](@ref) type
+Note that there are not actual type `Row`. See the [`Tables.AbstractRow`](@ref) type
 for a type to potentially subtype to gain useful default behaviors.
 
 ### `Columns`
@@ -258,8 +257,7 @@ Any object implements the `Columns` interface, by satisfying the following:
 | **Optional methods**                                     |                             |                                                                                                                                                              |
 | `Tables.getcolumn(table, ::Type{T}, i::Int, nm::Symbol)` | Tables.getcolumn(table, nm) | Given a column eltype `T`, index `i`, and column name `nm`, retrieve the column. Provides a type-stable or even constant-prop-able mechanism for efficiency. |
 
-Note that table sources shouldn't subtype `Columns`, as it is purely an interface type
-to help document the Tables.jl API. See the [`Tables.AbstractColumns`](@ref) type
+Note that there are no actual type `Columns`. See the [`Tables.AbstractColumns`](@ref) type
 for a type to potentially subtype to gain useful default behaviors.
 
 ### Abstract `Row` and `Columns` types

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -228,6 +228,7 @@ The high-level [`Tables.rows`](@ref) function returns a `Row`-compatible
 iterator from any input table source.
 
 Any object implements the `Row` interface, by satisfying the following:
+
 | Required Methods                                       | Default Definition        | Brief Description                                                                                                                                                |
 |--------------------------------------------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Tables.getcolumn(row, i::Int)`                        | getfield(row, i)          | Retrieve a column value by index                                                                                                                                 |
@@ -249,6 +250,7 @@ The high-level [`Tables.columns`](@ref) function returns a `Columns`-compatible
 object from any input table source.
 
 Any object implements the `Columns` interface, by satisfying the following:
+
 | Required Methods                                         | Default Definition          | Brief Description                                                                                                                                            |
 |----------------------------------------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Tables.getcolumn(table, i::Int)`                        | getfield(table, i)          | Retrieve a column by index                                                                                                                                   |

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -62,22 +62,6 @@ abstract type AbstractColumns end
 """
     Tables.Row
 
-An interface type that represents a single row of a table, with column values retrievable by name or index.
-The high-level [`Tables.rows`](@ref) function returns a `Row`-compatible
-iterator from any input table source.
-
-Any object implements the `Row` interface, by satisfying the following:
-| Required Methods                                       | Default Definition        | Brief Description                                                                                                                                                |
-|--------------------------------------------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Tables.getcolumn(row, i::Int)`                        | getfield(row, i)          | Retrieve a column value by index                                                                                                                                 |
-| `Tables.getcolumn(row, nm::Symbol)`                    | getproperty(row, nm)      | Retrieve a column value by name                                                                                                                                  |
-| `Tables.columnnames(row)`                              | propertynames(row)        | Return column names for a row as an indexable collection                                                                                                         |
-| **Optional methods**                                   |                           |                                                                                                                                                                  |
-| `Tables.getcolumn(row, ::Type{T}, i::Int, nm::Symbol)` | Tables.getcolumn(row, nm) | Given a column type `T`, index `i`, and column name `nm`, retrieve the column value. Provides a type-stable or even constant-prop-able mechanism for efficiency. |
-
-Note that custom row types shouldn't subtype `Row`, as it is purely an interface type
-to help document the Tables.jl API. See the [`Tables.AbstractRow`](@ref) type
-for a type to potentially subtype to gain useful default behaviors.
 """
 abstract type Row end
 
@@ -308,7 +292,7 @@ function columns end
 """
     Tables.rows(x) => Row iterator
 
-Accesses data of input table source `x` row-by-row by returning a [`Row`](@ref) iterator.
+Accesses data of input table source `x` row-by-row by returning a [`Row`](@ref Row) iterator.
 Note that even if the input table source is column-oriented by nature, an efficient generic
 definition of `Tables.rows` is defined in Tables.jl to return an iterator of row views into
 the columns of the input.

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -9,31 +9,6 @@ if !hasmethod(getproperty, Tuple{Tuple, Int})
 end
 
 """
-    Tables.Columns
-
-An interface type defined as an ordered set of columns that support
-retrieval of individual columns by name or index. A retrieved column
-must be an indexable collection with known length, i.e. an object
-that supports `length(col)` and `col[i]` for any `i = 1:length(col)`.
-The high-level [`Tables.columns`](@ref) function returns a `Columns`-compatible
-object from any input table source.
-
-Any object implements the `Columns` interface, by satisfying the following:
-| Required Methods                                         | Default Definition          | Brief Description                                                                                                                                            |
-|----------------------------------------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Tables.getcolumn(table, i::Int)`                        | getfield(table, i)          | Retrieve a column by index                                                                                                                                   |
-| `Tables.getcolumn(table, nm::Symbol)`                    | getproperty(table, nm)      | Retrieve a column by name                                                                                                                                    |
-| `Tables.columnnames(table)`                              | propertynames(table)        | Return column names for a table as an indexable collection                                                                                                   |
-| **Optional methods**                                     |                             |                                                                                                                                                              |
-| `Tables.getcolumn(table, ::Type{T}, i::Int, nm::Symbol)` | Tables.getcolumn(table, nm) | Given a column eltype `T`, index `i`, and column name `nm`, retrieve the column. Provides a type-stable or even constant-prop-able mechanism for efficiency. |
-
-Note that table sources shouldn't subtype `Columns`, as it is purely an interface type
-to help document the Tables.jl API. See the [`Tables.AbstractColumns`](@ref) type
-for a type to potentially subtype to gain useful default behaviors.
-"""
-abstract type Columns end
-
-"""
     Tables.AbstractColumns
 
 Abstract type provided to allow custom table types to inherit useful and required behavior. Note that this type
@@ -58,12 +33,6 @@ While custom table types aren't required to subtype `Tables.AbstractColumns`, be
 This allows a custom table type to behave as close as possible to a builtin `NamedTuple` of vectors object.
 """
 abstract type AbstractColumns end
-
-"""
-    Tables.Row
-
-"""
-abstract type Row end
 
 """
     Tables.AbstractRow
@@ -273,7 +242,7 @@ materializer(::Type{T}) where {T} = columntable
 """
     Tables.columns(x) => Columns-compatible object
 
-Accesses data of input table source `x` by returning a [`Columns`](@ref)-compatible
+Accesses data of input table source `x` by returning a [`Columns`](@ref Columns)-compatible
 object, which allows retrieving entire columns by name or index. A retrieved column
 is an object that is indexable and has a known length, i.e. supports 
 `length(col)` and `col[i]` for any `i = 1:length(col)`. Note that


### PR DESCRIPTION
I think it is a bit confusing that `Tables.Row` and `Tables.Columns` exist as actual types (though the docstrings do mention that they are only for documentation).  But maybe it's better to not introduce "dummy" types in the first place?

One idea may be to use markdown sections for documenting them. This is implemented in this PR.

---

Another way to do this is:

```julia
"""
...
"""
const Row = nothing
```

I think it is safer than `abstract type Row end` as users can't subtype `Row`.
