### PR TITLE
Add Tables.Row/Tables.Columns types for convenience. We also clarify …

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "0.2.11"
+version = "1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.0"
+version = "1.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -11,10 +11,13 @@ end
 """
     Tables.AbstractColumns
 
-Abstract type provided to allow custom table types to inherit useful and required behavior. Note that this type
-is for convenience for table _source_ authors to provide useful default behavior to their `Columns` object,
-and not to be used or relied upon by sink authors to dispatch on; i.e. not all `Columns` objects will inherit
-from `Tables.AbstractColumns`.
+An interface type defined as an ordered set of columns that support
+retrieval of individual columns by name or index. A retrieved column
+must be an indexable collection with known length, i.e. an object
+that supports `length(col)` and `col[i]` for any `i = 1:length(col)`.
+`Tables.columns` has an expected return type of `Tables.AbstractColumns`. Note that
+`Tables.columns` returned objects **are not** expected to subtype `Tables.AbstractColumns`, though they may
+in order to inherit some useful default behavior; custom types are only expected to satisfy the interface requirements.
 
 Interface definition:
 
@@ -26,10 +29,11 @@ Interface definition:
 | **Optional methods**                                     |                             |                                                                                                                                                              |
 | `Tables.getcolumn(table, ::Type{T}, i::Int, nm::Symbol)` | Tables.getcolumn(table, nm) | Given a column eltype `T`, index `i`, and column name `nm`, retrieve the column. Provides a type-stable or even constant-prop-able mechanism for efficiency. |
 
-While custom table types aren't required to subtype `Tables.AbstractColumns`, benefits of doing so include:
+While types aren't required to subtype `Tables.AbstractColumns`, benefits of doing so include:
   * Indexing interface defined (using `getcolumn`); i.e. `tbl[i]` will retrieve the column at index `i`
   * Property access interface defined (using `columnnames` and `getcolumn`); i.e. `tbl.col1` will retrieve column named `col1`
   * Iteration interface defined; i.e. `for col in table` will iterate each column in the table
+  * `AbstractDict` methods defined (`get`, `haskey`, etc.) for checking and retrieving columns
   * A default `show` method
 This allows a custom table type to behave as close as possible to a builtin `NamedTuple` of vectors object.
 """
@@ -38,10 +42,9 @@ abstract type AbstractColumns end
 """
     Tables.AbstractRow
 
-Abstract type provided to allow custom row types to inherit useful and required behavior. Note that this type
-is for convenience for table _source_ authors to provide useful default behavior to their `Row` object,
-and not to be used or relied upon by sink authors to dispatch on; i.e. not all `Row` objects will inherit
-from `Tables.AbstractRow`.
+Abstract interface type representing the expected `eltype` of the iterator returned from `Tables.rows(table)`. Note
+that `Tables.row` iterators **are not** expected to have elements that subtype `Tables.AbstractRow`, though they may
+in order ot inherit some useful default behavior; custom row types are only expected to satisfy the interface requirements.
 
 Interface definition:
 
@@ -57,23 +60,24 @@ While custom row types aren't required to subtype `Tables.AbstractRow`, benefits
   * Indexing interface defined (using `getcolumn`); i.e. `row[i]` will return the column value at index `i`
   * Property access interface defined (using `columnnames` and `getcolumn`); i.e. `row.col1` will retrieve the value for the column named `col1`
   * Iteration interface defined; i.e. `for x in row` will iterate each column value in the row
+  * `AbstractDict` methods defined (`get`, `haskey`, etc.) for checking and retrieving column values
   * A default `show` method
 This allows the custom row type to behave as close as possible to a builtin `NamedTuple` object.
 """
 abstract type AbstractRow end
 
 """
-    Tables.getcolumn(::Columns, nm::Symbol) => Indexable collection with known length
-    Tables.getcolumn(::Columns, i::Int) => Indexable collection with known length
-    Tables.getcolumn(::Columns, T, i::Int, nm::Symbol) => Indexable collection with known length
+    Tables.getcolumn(::AbstractColumns, nm::Symbol) => Indexable collection with known length
+    Tables.getcolumn(::AbstractColumns, i::Int) => Indexable collection with known length
+    Tables.getcolumn(::AbstractColumns, T, i::Int, nm::Symbol) => Indexable collection with known length
 
-    Tables.getcolumn(::Row, nm::Symbol) => Column value
-    Tables.getcolumn(::Row, i::Int) => Column value
-    Tables.getcolumn(::Row, T, i::Int, nm::Symbol) => Column value
+    Tables.getcolumn(::AbstractRow, nm::Symbol) => Column value
+    Tables.getcolumn(::AbstractRow, i::Int) => Column value
+    Tables.getcolumn(::AbstractRow, T, i::Int, nm::Symbol) => Column value
 
-Retrieve an entire column (`Columns`) or single row column value (`Row`) by column name (`nm`), index (`i`),
-or if desired, by column type (`T`), index (`i`), and name (`nm`). When called on a `Columns` interface object,
-a `Column` is returned, which is an indexable collection with known length. When called on a `Row` interface
+Retrieve an entire column (from `AbstractColumns`) or single row column value (from an `AbstractRow`) by column name (`nm`), index (`i`),
+or if desired, by column type (`T`), index (`i`), and name (`nm`). When called on a `AbstractColumns` interface object,
+the returned object should be an indexable collection with known length. When called on a `AbstractRow` interface
 object, it returns the single column value. The methods taking a single `Symbol` or `Int` are both required
 for the `AbstractColumns` and `AbstractRow` interfaces; the third method is optional if type stability is possible.
 The default definition of `Tables.getcolumn(x, i::Int)` is `getfield(x, i)`. The default definition of
@@ -87,32 +91,51 @@ getcolumn(x, ::Type{T}, i::Int, nm::Symbol) where {T} = getcolumn(x, nm)
 getcolumn(x::NamedTuple{names, types}, ::Type{T}, i::Int, nm::Symbol) where {names, types, T} = Core.getfield(x, i)
 
 """
-    Tables.columnnames(::Union{Columns, Row}) => Indexable collection
+    Tables.columnnames(::Union{AbstractColumns, AbstractRow}) => Indexable collection
 
-Retrieves the list of column names as an indexable collection (like a `Tuple` or `Vector`) for a `Columns` or `Row` interface object. The default definition calls `propertynames(x)`.
+Retrieves the list of column names as an indexable collection (like a `Tuple` or `Vector`) for a `AbstractColumns` or `AbstractRow` interface object. The default definition calls `propertynames(x)`.
 """
 function columnnames end
 
 columnnames(x) = propertynames(x)
 
-# default definitions for AbstractDict to act as Row
+"""
+    Tables.isrowtable(x) => Bool
+
+For convenience, some table objects that are naturally "row oriented" can
+define `Tables.isrowtable(::Type{TableType}) = true` to simplify satisfying the
+Tables.jl interface. Requirements for defining `isrowtable` include:
+  * `Tables.rows(x) === x`, i.e. the table object itself is a `Row` iterator
+  * If the table object is mutable, it should support:
+    * `push!(x, row)`: allow pushing a single row onto table
+    * `append!(x, rows)`: allow appending set of rows onto table
+  * If table object is mutable and indexable, it should support:
+    * `x[i] = row`: allow replacing of a row with another row by index
+
+A table object that defines `Tables.isrowtable` will have definitions for
+`Tables.istable`, `Tables.rowaccess`, and `Tables.rows` automatically defined.
+"""
+function isrowtable end
+
+isrowtable(::T) where {T} = isrowtable(T)
+isrowtable(::Type{T}) where {T} = false
+
+# default definitions for AbstractDict to act as an AbstractColumns or AbstractRow
 getcolumn(x::AbstractDict, i::Int) = x[i]
 getcolumn(x::AbstractDict, nm::Symbol) = x[nm]
 getcolumn(x::AbstractDict, ::Type{T}, i::Int, nm::Symbol) where {T} = x[nm]
 columnnames(x::AbstractDict) = collect(keys(x))
 
-# Dict iterator as Rows
+# AbstractVector of Dicts for Tables.rows
 const DictRows = AbstractVector{T} where {T <: AbstractDict}
-istable(::Type{<:DictRows}) = true
-rowaccess(::Type{<:DictRows}) = true
-rows(x::DictRows) = x
+isrowtable(::Type{<:DictRows}) = true
 # DictRows doesn't naturally lend itself to the `Tables.schema` requirement
 # we can't just look at the first row, because the types might change,
 # row-to-row (e.g. `missing`, then `1.1`, etc.). Therefore, the safest option
 # is to just return `nothing`
 schema(x::DictRows) = nothing
 
-# and as Columns
+# Dict of AbstractVectors for Tables.columns
 const DictColumns = AbstractDict{K, V} where {K <: Union{Integer, Symbol, String}, V <: AbstractVector}
 istable(::Type{<:DictColumns}) = true
 columnaccess(::Type{<:AbstractDict}) = true
@@ -127,6 +150,7 @@ const RorC = Union{AbstractRow, AbstractColumns}
 
 Base.IteratorSize(::Type{R}) where {R <: RorC} = Base.HasLength()
 Base.length(r::RorC) = length(columnnames(r))
+Base.IndexStyle(::Type{<:RorC}) = Base.IndexLinear()
 Base.firstindex(r::RorC) = 1
 Base.lastindex(r::RorC) = length(r)
 Base.getindex(r::RorC, i::Int) = getcolumn(r, i)
@@ -151,9 +175,7 @@ end
 
 # AbstractRow AbstractVector as Rows
 const AbstractRowTable = AbstractVector{T} where {T <: AbstractRow}
-istable(::Type{<:AbstractRowTable}) = true
-rowaccess(::Type{<:AbstractRowTable}) = true
-rows(x::AbstractRowTable) = x
+isrowtable(::Type{<:AbstractRowTable}) = true
 schema(x::AbstractRowTable) = nothing
 
 # AbstractColumns as Columns
@@ -163,25 +185,45 @@ columns(x::AbstractColumns) = x
 schema(x::AbstractColumns) = nothing
 
 """
-    Tables.isrowtable(x) => Bool
+    Tables.Row(row)
 
-For convenience, some table objects that are naturally "row oriented" can
-define `Tables.isrowtable(::Type{TableType}) = true` to simplify satisfying the
-Tables.jl interface. Requirements for defining `isrowtable` include:
-  * `Tables.rows(x) === x`, i.e. the table object itself is a `Row` iterator
-  * If the table object is mutable, it should support:
-    * `push!(x, row)`: allow pushing a single row onto table
-    * `append!(x, rows)`: allow appending set of rows onto table
-  * If table object is mutable and indexable, it should support:
-    * `x[i] = row`: allow replacing of a row with another row by index
-
-A table object that defines `Tables.isrowtable` will have definitions for
-`Tables.istable`, `Tables.rowaccess`, and `Tables.rows` automatically defined.
+Convenience type to wrap any `AbstractRow` interface object in a dedicated struct
+to provide useful default behaviors (allows any `AbstractRow` to be used like a `NamedTuple`):
+  * Indexing interface defined; i.e. `row[i]` will return the column value at index `i`, `row[nm]` will return column value for column name `nm`
+  * Property access interface defined; i.e. `row.col1` will retrieve the value for the column named `col1`
+  * Iteration interface defined; i.e. `for x in row` will iterate each column value in the row
+  * `AbstractDict` methods defined (`get`, `haskey`, etc.) for checking and retrieving column values
 """
-function isrowtable end
+struct Row{T} <: AbstractRow
+    x::T
+end
 
-isrowtable(::T) where {T} = isrowtable(T)
-isrowtable(::Type{T}) where {T} = false
+Row(x::AbstractRow) = x
+
+"""
+    Tables.Columns(columns)
+
+Convenience type to wrap any `AbstractColumns` interface object in a dedicated struct
+to provide useful default behaviors (allows any `AbstractColumns` to be used like a `NamedTuple` of `Vectors`):
+  * Indexing interface defined; i.e. `row[i]` will return the column at index `i`, `row[nm]` will return column for column name `nm`
+  * Property access interface defined; i.e. `row.col1` will retrieve the value for the column named `col1`
+  * Iteration interface defined; i.e. `for x in row` will iterate each column in the row
+  * `AbstractDict` methods defined (`get`, `haskey`, etc.) for checking and retrieving columns
+"""
+struct Columns{T} <: AbstractColumns
+    x::T
+end
+
+Columns(x::AbstractColumns) = x
+
+const RorC2 = Union{Row, Columns}
+
+getx(x::RorC2) = getfield(x, :x)
+
+getcolumn(x::RorC2, i::Int) = getcolumn(getx(x), i)
+getcolumn(x::RorC2, nm::Symbol) = getcolumn(getx(x), nm)
+getcolumn(x::RorC2, ::Type{T}, i::Int, nm::Symbol) where {T} = getcolumn(getx(x), T, i, nm)
+columnnames(x::RorC2) = columnnames(getx(x))
 
 """
     Tables.istable(x) => Bool
@@ -189,7 +231,7 @@ isrowtable(::Type{T}) where {T} = false
 Check if an object has specifically defined that it is a table. Note that 
 not all valid tables will return true, since it's possible to satisfy the
 Tables.jl interface at "run-time", e.g. a `Generator` of `NamedTuple`s iterates
-`NamedTuple`s, which satisfies the Row interface, but there's no static way
+`NamedTuple`s, which satisfies the `AbstractRow` interface, but there's no static way
 of knowing that the generator is a table.
 """
 function istable end
@@ -203,13 +245,13 @@ istable(::Type{T}) where {T} = isrowtable(T)
 Check whether an object has specifically defined that it implements the `Tables.rows`
 function that does _not_ copy table data.  That is to say, `Tables.rows(x)` must be done
 with O(1) time and space complexity when `Tables.rowaccess(x) == true`.  Note that
-`Tables.rows` will work on any object that iterates `Row`-compatible objects, even if
+`Tables.rows` will work on any object that iterates `AbstractRow`-compatible objects, even if
 they don't define `rowaccess`, e.g. a `Generator` of `NamedTuple`s.  However, this
 generic fallback may copy the data from input table `x`.  Also note that just because
 an object defines `rowaccess` doesn't mean a user should call `Tables.rows` on it;
-`Tables.columns` will also work, providing a valid `Columns` object from the rows.
+`Tables.columns` will also work, providing a valid `AbstractColumns` object from the rows.
 Hence, users should call `Tables.rows` or `Tables.columns` depending on what is most
-natural for them to *consume* instead of worrying about what and how the input produces.
+natural for them to *consume* instead of worrying about what and how the input is oriented.
 """
 function rowaccess end
 
@@ -222,13 +264,13 @@ rowaccess(::Type{T}) where {T} = isrowtable(T)
 Check whether an object has specifically defined that it implements the `Tables.columns`
 function that does _not_ copy table data.  That is to say, `Tables.columns(x)` must be done
 with O(1) time and space complexity when `Tables.columnaccess(x) == true`.  Note that
-`Tables.columns` has generic fallbacks allowing it to produces `Columns` objects, even if
+`Tables.columns` has generic fallbacks allowing it to produces `AbstractColumns` objects, even if
 the input doesn't define `columnaccess`.  However, this generic fallback may copy the data
 from input table `x`.  Also note that just because an object defines `columnaccess` doesn't
 mean a user should call `Tables.columns` on it; `Tables.rows` will also work, providing a
-valid `Row` iterator. Hence, users should call `Tables.rows` or `Tables.columns` depending
+valid `AbstractRow` iterator. Hence, users should call `Tables.rows` or `Tables.columns` depending
 on what is most natural for them to *consume* instead of worrying about what and how the
-input produces.
+input is oriented.
 """
 function columnaccess end
 
@@ -239,7 +281,7 @@ columnaccess(::Type{T}) where {T} = false
     Tables.schema(x) => Union{Nothing, Tables.Schema}
 
 Attempt to retrieve the schema of the object returned by `Tables.rows` or `Tables.columns`.
-If the `Row` iterator or `Columns` object can't determine its schema, `nothing` will be returned.
+If the `AbstractRow` iterator or `AbstractColumns` object can't determine its schema, `nothing` will be returned.
 Otherwise, a `Tables.Schema` object is returned, with the column names and types available for use.
 """
 function schema end
@@ -262,19 +304,19 @@ materializer(x::T) where {T} = materializer(T)
 materializer(::Type{T}) where {T} = columntable
 
 """
-    Tables.columns(x) => Columns-compatible object
+    Tables.columns(x) => AbstractColumns-compatible object
 
-Accesses data of input table source `x` by returning a [`Columns`](@ref Columns)-compatible
+Accesses data of input table source `x` by returning an [`AbstractColumns`](@ref)-compatible
 object, which allows retrieving entire columns by name or index. A retrieved column
 is an object that is indexable and has a known length, i.e. supports 
 `length(col)` and `col[i]` for any `i = 1:length(col)`. Note that
 even if the input table source is row-oriented by nature, an efficient generic
-definition of `Tables.columns` is defined in Tables.jl to build a `Columns`-
+definition of `Tables.columns` is defined in Tables.jl to build a `AbstractColumns`-
 compatible object object from the input rows.
 
-The [`Tables.Schema`](@ref) of a `Columns` object can be queried via `Tables.schema(columns)`,
+The [`Tables.Schema`](@ref) of a `AbstractColumns` object can be queried via `Tables.schema(columns)`,
 which may return `nothing` if the schema is unknown.
-Column names can be queried by calling `Tables.columnnames(columns)`. And individual columns
+Column names can always be queried by calling `Tables.columnnames(columns)`, and individual columns
 can be accessed by calling `Tables.getcolumn(columns, i::Int )` or `Tables.getcolumn(columns, nm::Symbol)`
 with a column index or name, respectively.
 """
@@ -283,15 +325,15 @@ function columns end
 """
     Tables.rows(x) => Row iterator
 
-Accesses data of input table source `x` row-by-row by returning a [`Row`](@ref Row) iterator.
+Accesses data of input table source `x` row-by-row by returning an [`AbstractRow`](@ref)-compatible iterator.
 Note that even if the input table source is column-oriented by nature, an efficient generic
 definition of `Tables.rows` is defined in Tables.jl to return an iterator of row views into
 the columns of the input.
 
-The [`Tables.Schema`](@ref) of a `Row` iterator can be queried via `Tables.schema(rows)`,
+The [`Tables.Schema`](@ref) of an `AbstractRow` iterator can be queried via `Tables.schema(rows)`,
 which may return `nothing` if the schema is unknown.
-Column names can be queried by calling `Tables.columnnames(row)` on an individual row.
-And row values can be accessed by calling `Tables.getcolumn(rows, i::Int )` or
+Column names can always be queried by calling `Tables.columnnames(row)` on an individual row,
+and row values can be accessed by calling `Tables.getcolumn(rows, i::Int )` or
 `Tables.getcolumn(rows, nm::Symbol)` with a column index or name, respectively.
 """
 function rows end
@@ -300,15 +342,16 @@ function rows end
 """
     Tables.Schema(names, types)
 
-Create a `Tables.Schema` object that holds the column names and types for a tabular data object.
+Create a `Tables.Schema` object that holds the column names and types for an `AbstractRow` iterator
+returned from `Tables.rows` or an `AbstractColumns` object returned from `Tables.columns`.
 `Tables.Schema` is dual-purposed: provide an easy interface for users to query these properties,
 as well as provide a convenient "structural" type for code generation.
 
-To get a table's schema, one can call `Tables.schema(tbl)`, but also note that a table may return `nothing`,
-indicating that it's column names and/or column types are unknown (usually not inferrable). This is similar
-to the `Base.EltypeUnknown()` trait for iterators when `Base.IteratorEltype` is called. Users should account
-for the `Tables.schema(tbl) => nothing` case by using the properties of the results of `Tables.rows(x)` and `Tables.columns(x)`
-directly.
+To get a table's schema, one can call `Tables.schema` on the result of `Tables.rows` or `Tables.columns`,
+but also note that a table may return `nothing`, indicating that its column names and/or column types
+are unknown (usually not inferrable). This is similar to the `Base.EltypeUnknown()` trait for iterators
+when `Base.IteratorEltype` is called. Users should account for the `Tables.schema(tbl) => nothing` case
+by using the properties of the results of `Tables.rows(x)` and `Tables.columns(x)` directly.
 
 To access the names, one can simply call `sch.names` to return the tuple of Symbols.
 To access column types, one can similarly call `sch.types`, which will return a tuple of types (like `(Int64, Float64, String)`).
@@ -377,5 +420,29 @@ columnindex(table, colname) = columnindex(schema(table), colname)
 Return the column type of a column by `name` in a table with a known schema; returns Union{} if `name` doesn't exist in table
 """
 columntype(table, colname) = columntype(schema(table), colname)
+
+Base.@pure columnindex(::Schema{names, types}, name::Symbol) where {names, types} = columnindex(names, name)
+
+"given names and a Symbol `name`, compute the index (1-based) of the name in names"
+Base.@pure function columnindex(names::Tuple{Vararg{Symbol}}, name::Symbol)
+    i = 1
+    for nm in names
+        nm === name && return i
+        i += 1
+    end
+    return 0
+end
+
+Base.@pure columntype(::Schema{names, types}, name::Symbol) where {names, types} = columntype(names, types, name)
+
+"given tuple type and a Symbol `name`, compute the type of the name in the tuples types"
+Base.@pure function columntype(names::Tuple{Vararg{Symbol}}, ::Type{types}, name::Symbol) where {types <: Tuple}
+    i = 1
+    for nm in names
+        nm === name && return fieldtype(types, i)
+        i += 1
+    end
+    return Union{}
+end
 
 end # module

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -15,9 +15,11 @@ An interface type defined as an ordered set of columns that support
 retrieval of individual columns by name or index. A retrieved column
 must be an indexable collection with known length, i.e. an object
 that supports `length(col)` and `col[i]` for any `i = 1:length(col)`.
-`Tables.columns` has an expected return type of `Tables.AbstractColumns`. Note that
-`Tables.columns` returned objects **are not** expected to subtype `Tables.AbstractColumns`, though they may
-in order to inherit some useful default behavior; custom types are only expected to satisfy the interface requirements.
+`Tables.columns` must return an object that satisfies the `Tables.AbstractColumns` interface.
+While `Tables.AbstractColumns` is an abstract type that custom "columns" types may subtype for
+useful default behavior (indexing, iteration, property-access, etc.), users should not use it
+for dispatch, as Tables.jl interface objects ***are not required*** to subtype, but only
+implement the required interface methods.
 
 Interface definition:
 
@@ -42,9 +44,12 @@ abstract type AbstractColumns end
 """
     Tables.AbstractRow
 
-Abstract interface type representing the expected `eltype` of the iterator returned from `Tables.rows(table)`. Note
-that `Tables.row` iterators **are not** expected to have elements that subtype `Tables.AbstractRow`, though they may
-in order ot inherit some useful default behavior; custom row types are only expected to satisfy the interface requirements.
+Abstract interface type representing the expected `eltype` of the iterator returned from `Tables.rows(table)`.
+`Tables.rows` must return an iterator of elements that satisfy the `Tables.AbstractRow` interface.
+While `Tables.AbstractRow` is an abstract type that custom "row" types may subtype for
+useful default behavior (indexing, iteration, property-access, etc.), users should not use it
+for dispatch, as Tables.jl interface objects ***are not required*** to subtype, but only
+implement the required interface methods.
 
 Interface definition:
 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -63,18 +63,18 @@ ignored in the conversion. By default, input table columns will be materialized 
 matrix columns; passing `transpose=true` will transpose the input with input columns as matrix rows.
 """
 function matrix(table; transpose::Bool=false)
-    cols = Tables.columns(table)
+    cols = columns(table)
     types = schema(cols).types
     T = reduce(promote_type, types)
     n, p = rowcount(cols), length(types)
     if !transpose
         mat = Matrix{T}(undef, n, p)
-        for (i, col) in enumerate(Tables.eachcolumn(cols))
+        for (i, col) in enumerate(Columns(cols))
             mat[:, i] = col
         end
     else
         mat = Matrix{T}(undef, p, n)
-        for (i, col) in enumerate(Tables.eachcolumn(cols))
+        for (i, col) in enumerate(Columns(cols))
             mat[i, :] = col
         end
     end

--- a/src/namedtuples.jl
+++ b/src/namedtuples.jl
@@ -127,7 +127,7 @@ function columntable(sch::Schema{names, types}, cols) where {names, types}
 end
 
 # unknown schema case
-columntable(::Nothing, cols) = NamedTuple{Tuple(Base.map(Symbol, columnnames(cols)))}(Tuple(getarray(col) for col in eachcolumn(cols)))
+columntable(::Nothing, cols) = NamedTuple{Tuple(Base.map(Symbol, columnnames(cols)))}(Tuple(getarray(getcolumn(cols, col)) for col in columnnames(cols)))
 
 function columntable(itr::T) where {T}
     cols = columns(itr)

--- a/src/namedtuples.jl
+++ b/src/namedtuples.jl
@@ -73,7 +73,7 @@ Take any input table source, and produce a `Vector` of `NamedTuple`s,
 also known as a "row table". A "row table" is a kind of default
 table type of sorts, since it satisfies the Tables.jl row interface
 naturally, i.e. a `Vector` naturally iterates its elements, and
-`NamedTuple` satisifes the `Row` interface by default (allows
+`NamedTuple` satisifes the `AbstractRow` interface by default (allows
 indexing value by index, name, and getting all names).
 """
 function rowtable end
@@ -97,6 +97,9 @@ _eltype(::Type{A}) where {A <: AbstractVector{T}} where {T} = T
 Base.@pure function _eltypes(::Type{NT}) where {NT <: NamedTuple{names, T}} where {names, T <: NTuple{N, AbstractVector{S} where S}} where {N}
     return Tuple{Any[ _eltype(fieldtype(NT, i)) for i = 1:fieldcount(NT) ]...}
 end
+
+names(::Type{NamedTuple{nms, T}}) where {nms, T} = nms
+types(::Type{NamedTuple{nms, T}}) where {nms, T} = T
 
 schema(x::T) where {T <: ColumnTable} = Schema(names(T), _eltypes(T))
 materializer(x::ColumnTable) = columntable

--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -17,7 +17,7 @@ end
     Tables.nondatavaluerows(x)
 
 Takes any Queryverse-compatible `NamedTuple` iterator source and 
-converts to a Tables.jl-compatible `Row` iterator. Will automatically
+converts to a Tables.jl-compatible `AbstractRow` iterator. Will automatically
 unwrap any `DataValue`s, replacing `NA` with `missing`.
 Useful for translating Query.jl results back to non-`DataValue`-based tables.
 """
@@ -39,7 +39,7 @@ Base.IteratorSize(::Type{IteratorWrapper{S}}) where {S} = Base.IteratorSize(S)
 Base.length(rows::IteratorWrapper) = length(rows.x)
 Base.size(rows::IteratorWrapper) = size(rows.x)
 
-@noinline invalidtable(::T, ::S) where {T, S} = throw(ArgumentError("'$T' iterates '$S' values, which doesn't satisfy the Tables.jl Row-iterator interface"))
+@noinline invalidtable(::T, ::S) where {T, S} = throw(ArgumentError("'$T' iterates '$S' values, which doesn't satisfy the Tables.jl `AbstractRow` interface"))
 
 @inline function Base.iterate(rows::IteratorWrapper)
     x = iterate(rows.x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,8 @@ using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceEx
     nt = (a=1, b=2, c=3)
     NT = typeof(nt)
     output = [0, 0, 0]
-    Tables.eachcolumn(Tables.Schema(Tables.names(NT), Tables.types(NT)), nt, output) do val, col, nm, out
-        out[col] = val
+    Tables.eachcolumn(Tables.Schema(Tables.names(NT), Tables.types(NT)), nt) do val, col, nm
+        output[col] = val
     end
     @test output == [1, 2, 3]
 
@@ -41,8 +41,8 @@ using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceEx
     NT = typeof(nt)
     @test Tables.runlength(Tables.types(NT)) == [(Int, 101)]
     output = zeros(Int, 101)
-    Tables.eachcolumn(Tables.Schema(Tables.names(NT), Tables.types(NT)), nt, output) do val, col, nm, out
-        out[col] = val
+    Tables.eachcolumn(Tables.Schema(Tables.names(NT), Tables.types(NT)), nt) do val, col, nm
+        output[col] = val
     end
     @test output == [i for i = 1:101]
 
@@ -50,8 +50,8 @@ using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceEx
     NT = typeof(nt)
     @test Tables.runlength(Tables.types(NT)) == [i % 2 == 0 ? (Int, 1) : (String, 1) for i = 1:101]
     output = Vector{Any}(undef, 101)
-    Tables.eachcolumn(Tables.Schema(Tables.names(NT), Tables.types(NT)), nt, output) do val, col, nm, out
-        out[col] = val
+    Tables.eachcolumn(Tables.Schema(Tables.names(NT), Tables.types(NT)), nt) do val, col, nm
+        output[col] = val
     end
     @test output == [i % 2 == 0 ? i : "$i" for i = 1:101]
 
@@ -63,7 +63,6 @@ using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceEx
     @test nt.b[] == 2
 
     nt = (a=[1,2,3], b=[4,5,6])
-    @test collect(Tables.eachcolumn(nt)) == [[1,2,3], [4,5,6]]
     @test Tables.columnindex(nt, :i) == 0
     @test Tables.columnindex(nt, :a) == 1
     @test Tables.columntype(nt, :a) == Int


### PR DESCRIPTION
…language to always refer to AbstractRow/AbstractColumns as the interfaces and abstract types.