### PR TITLE
Cleanup Dict tables support

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -126,13 +126,13 @@ isrowtable(::T) where {T} = isrowtable(T)
 isrowtable(::Type{T}) where {T} = false
 
 # default definitions for AbstractDict to act as an AbstractColumns or AbstractRow
-getcolumn(x::AbstractDict, i::Int) = x[i]
-getcolumn(x::AbstractDict, nm::Symbol) = x[nm]
-getcolumn(x::AbstractDict, ::Type{T}, i::Int, nm::Symbol) where {T} = x[nm]
-columnnames(x::AbstractDict) = collect(keys(x))
+getcolumn(x::AbstractDict{Symbol}, i::Int) = x[columnnames(x)[i]]
+getcolumn(x::AbstractDict{Symbol}, nm::Symbol) = x[nm]
+getcolumn(x::AbstractDict{Symbol}, ::Type{T}, i::Int, nm::Symbol) where {T} = x[nm]
+columnnames(x::AbstractDict{Symbol}) = collect(keys(x))
 
 # AbstractVector of Dicts for Tables.rows
-const DictRows = AbstractVector{T} where {T <: AbstractDict}
+const DictRows = AbstractVector{T} where {T <: AbstractDict{Symbol}}
 isrowtable(::Type{<:DictRows}) = true
 # DictRows doesn't naturally lend itself to the `Tables.schema` requirement
 # we can't just look at the first row, because the types might change,
@@ -141,14 +141,14 @@ isrowtable(::Type{<:DictRows}) = true
 schema(x::DictRows) = nothing
 
 # Dict of AbstractVectors for Tables.columns
-const DictColumns = AbstractDict{K, V} where {K <: Union{Integer, Symbol, String}, V <: AbstractVector}
+const DictColumns = AbstractDict{K, V} where {K <: Symbol, V <: AbstractVector}
 istable(::Type{<:DictColumns}) = true
-columnaccess(::Type{<:AbstractDict}) = true
+columnaccess(::Type{<:DictColumns}) = true
 columns(x::DictColumns) = x
 schema(x::DictColumns) = Schema(collect(keys(x)), eltype.(values(x)))
 
 # for other AbstractDict, let's throw an informative error
-columns(x::T) where {T <: AbstractDict} = error("to treat $T as a table, it must have a key type of `Integer`, `Symbol`, or `String`, and a value type `<: AbstractVector`")
+columns(x::T) where {T <: AbstractDict} = error("to treat $T as a table, it must have a key type of `Symbol`, and a value type `<: AbstractVector`")
 
 # default definitions for AbstractRow, AbstractColumns
 const RorC = Union{AbstractRow, AbstractColumns}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -433,7 +433,6 @@ end
 
     # a Dict w/ scalar values isn't a table
     @test_throws Exception Tables.columns(d)
-    @test_throws Exception Tables.rows(d)
 end
 
 struct Row <: Tables.AbstractRow


### PR DESCRIPTION
Fix #159. The issue here is that we were probably a bit too eager in the
Tables.jl support added for Dicts in the initial 1.0 release.
Specifically, we defined `getcolumn` for any `AbstractDict` with
whatever key type. In addition, in the error message for `AbstractDict`
without `Integer`, `String`, or `Symbol` key types, we said they needed
a key type of one of those three. The problem is that our `getcolumn`
definitions weren't correct for all three of those key types. The other
problem is that the Tables.jl interface requires `Symbol` column names,
so saying we supported `AbstractDict` with `String` key type was
misleading; that is, even if we had the correct `getcolumn` definitions
for `String` key types, sink functions all over aren't expecting
`String`s and may have unexpected or broken behavior (like CSV.jl
originally reported in #159).

This change restricts all Tables.jl support to `AbstractDict{Symbol}`,
thus requiring `Symbol` key type. While technically breaking, this was
new functionality introduced in 1.0 and was arguably broken on arrival,
since `getcolumn` didn't work for `Integer`/`String` key types anyway,
in addition to sink functions probably also being broken. Restricting it
now should make `AbstractDict` support more predictable with Tables.jl
and opens up room to potentially support more in the future.