### PR TITLE
Ensure AbstractMatrix instances aren't `Tables.istable`

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,3 +1,4 @@
+istable(::AbstractMatrix) = false
 istable(::Type{<:AbstractMatrix}) = false
 
 rows(m::T) where {T <: AbstractMatrix} = throw(ArgumentError("a '$T' is not a table; see `?Tables.table` for ways to treat an AbstractMatrix as a table"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,6 +244,8 @@ end
     T = Tables.table(hcat([1,2,3],[1,2,3]))
     M = Tables.matrix(T)
     @test M[:, 1] == [1, 2, 3]
+    # 167
+    @test !Tables.istable(Matrix{Union{}}(undef, 2, 3))
 end
 
 import Base: ==


### PR DESCRIPTION
The issue here is we only had a single definitione for `AbstractMatrix`
_types_ to be declared `false` to `istable`, but the default definition
for `istable` checks if the instance is iterable (for generators, etc.
to try and allow them to be tables), which, in this case, was including
`AbstractMatrix` instances because they're iterable.