### PR TITLE
add `matrix(table::MatrixTable)` method

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -59,10 +59,12 @@ end
 """
     Tables.matrix(table; transpose::Bool=false)
 
-Materialize any table source input as a `Matrix`. If the table column types are not homogenous,
+Materialize any table source input as a new `Matrix` or in the case of a `MatrixTable`
+return the originally wrapped matrix. If the table column types are not homogenous,
 they will be promoted to a common type in the materialized `Matrix`. Note that column names are
 ignored in the conversion. By default, input table columns will be materialized as corresponding
-matrix columns; passing `transpose=true` will transpose the input with input columns as matrix rows.
+matrix columns; passing `transpose=true` will transpose the input with input columns as matrix rows
+or in the case of a `MatrixTable` apply `permutedims` to the originally wrapped matrix.
 """
 function matrix(table; transpose::Bool=false)
     cols = columns(table)
@@ -81,4 +83,10 @@ function matrix(table; transpose::Bool=false)
         end
     end
     return matrix
+end
+	
+function matrix(table::MatrixTable; transpose::Bool=false) 
+    matrix = getfield(table, :matrix)
+    transpose || return matrix
+    return permutedims(matrix)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,7 +198,7 @@ end
     rt = [(a=1, b=4.0, c="7"), (a=2, b=5.0, c="8"), (a=3, b=6.0, c="9")]
     nt = (a=[1,2,3], b=[4.0, 5.0, 6.0])
 
-    mat = Tables.(rt)
+    mat = Tables.matrix(rt)
     @test nt.a == mat[:, 1]
     @test size(mat) == (3, 3)
     @test eltype(mat) == Any

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,7 +198,7 @@ end
     rt = [(a=1, b=4.0, c="7"), (a=2, b=5.0, c="8"), (a=3, b=6.0, c="9")]
     nt = (a=[1,2,3], b=[4.0, 5.0, 6.0])
 
-    mat = Tables.matrix(rt)
+    mat = Tables.(rt)
     @test nt.a == mat[:, 1]
     @test size(mat) == (3, 3)
     @test eltype(mat) == Any
@@ -241,9 +241,12 @@ end
     @test propertynames(mattbl) == propertynames(matrow) == [:Column1, :Column2, :Column3]
 
     # #155
-    T = Tables.table(hcat([1,2,3],[1,2,3]))
+    m = hcat([1,2,3],[1,2,3])
+    T = Tables.table(m)
     M = Tables.matrix(T)
     @test M[:, 1] == [1, 2, 3]
+    # 182
+    @test M === m #checks that both are the same object in memory
     # 167
     @test !Tables.istable(Matrix{Union{}}(undef, 2, 3))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,9 +244,11 @@ end
     m = hcat([1,2,3],[1,2,3])
     T = Tables.table(m)
     M = Tables.matrix(T)
+    Mt = Tables.matrix(T, transpose=true)
     @test M[:, 1] == [1, 2, 3]
     # 182
     @test M === m #checks that both are the same object in memory
+    @test Mt == permutedims(m) 
     # 167
     @test !Tables.istable(Matrix{Union{}}(undef, 2, 3))
 end


### PR DESCRIPTION
This PR resolves #182 by adding specific method for `matrix(table::MatrixTable)`. This avoids creating a copy of the wrapped matrix.