### PR TITLE
Avoid columnnames in rowcount fallback

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -5,11 +5,7 @@
 # Turn any AbstractColumns into an AbstractRow iterator
 
 # get the number of rows in the incoming table
-function rowcount(cols)
-    names = columnnames(cols)
-    isempty(names) && return 0
-    return length(getcolumn(cols, names[1]))
-end
+rowcount(table) = length(rows(table))
 
 # a lazy row view into a AbstractColumns object
 struct ColumnsRow{T} <: AbstractRow


### PR DESCRIPTION
Is it ok to refactor the fallback like this? I was having errors downstream because some table types did not define `columnnames`. Is it correct that any table type will have a fallback for `rows` and that we can just take the length of the rows for the count? Could we have similarly `columncount(table) = length(columns(table))`?