### PR TITLE
Remove istable for a value of type AbstractMatrix

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,4 +1,3 @@
-istable(::AbstractMatrix) = false
 istable(::Type{<:AbstractMatrix}) = false
 
 rows(m::T) where {T <: AbstractMatrix} = throw(ArgumentError("a '$T' is not a table; see `?Tables.table` for ways to treat an AbstractMatrix as a table"))


### PR DESCRIPTION
I think - as in other places - we should only define a method for a type, and use a default fallback for the value.

@quinnj Was there some specific reason why in this case a method for a value was introduced?