### PR TITLE
avoid reallocating `header`

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -60,14 +60,14 @@ Tables.jl interface. This allows accessing the matrix via `Tables.rows` and `Tab
 
 Note that no copy of the `AbstractMatrix`is made.
 """
-function table(matrix::AbstractMatrix; header=[Symbol("Column$i") for i = 1:size(m, 2)], reuse_header=false)
+function table(matrix::AbstractMatrix; header=[Symbol("Column$i") for i = 1:size(matrix, 2)], reuse_header=false)
     if header isa Vector{Symbol} && reuse_header
 	symbol_header = header
     else
 	symbol_header = [Symbol(h) for h in header]
     end	
     if length(symbol_header) != size(matrix, 2)
-        throw(ArgumentError("provided column names `header` length must match number of columns in matrix ($(size(m, 2)))"))
+        throw(ArgumentError("provided column names `header` length must match number of columns in matrix ($(size(matrix, 2)))"))
     end
     lookup = Dict(nm=>i for (i, nm) in enumerate(symbol_header))
     return MatrixTable(symbol_header, lookup, matrix)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -52,7 +52,7 @@ An optional keyword argument iterator `header` can be passed which will be conve
 is made, but `header` is always stored as freshly allocated object.
 """
 function table(m::AbstractMatrix; header=[Symbol("Column$i") for i = 1:size(m, 2)])
-    symbol_header = [Symbol(h) for h in header]
+    symbol_header = header isa Vector{Symbol} ? header : [Symbol(h) for h in header]
     if length(symbol_header) != size(m, 2)
         throw(ArgumentError("provided column names `header` length must match number of columns in matrix ($(size(m, 2)))"))
     end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -43,21 +43,34 @@ getcolumn(m::MatrixTable, i::Int) = getfield(m, :matrix)[:, i]
 columnnames(m::MatrixTable) = names(m)
 
 """
-    Tables.table(m::AbstractMatrix; [header])
+    Tables.table(matrix::AbstractMatrix; [header])
 
 Wrap an `AbstractMatrix` (`Matrix`, `Adjoint`, etc.) in a `MatrixTable`, which satisfies the
-Tables.jl interface. This allows accessing the matrix via `Tables.rows` and `Tables.columns`.
-An optional keyword argument iterator `header` can be passed which will be converted to a
-`Vector{Symbol}` to be used as the column names. Note that no copy of the `AbstractMatrix`
-is made, but `header` is always stored as freshly allocated object.
+Tables.jl interface. This allows accessing the matrix via `Tables.rows` and `Tables.columns`
+
+# Arguments.
+- `matrix::AbstractMatrix`: The matrix to be wrapped in a `MatrixTable`.
+
+# Keywords
+- `header::Any=[Symbol("Column$i") for i = 1:size(matrix, 2)]`: An iterator(e.g `Tuple` or `AbstractVector`) 
+    to be used as the column names in  the `MatrixTable`.
+- `reuse_header::Bool=true`: if set to `false` and `header::Vector{Symbol}` then the `header` passed is re-used 
+    as the column names of the `MatrixTable` else a freshly allocated `Vector{Symbol}` object derived from `header` 
+    is used as the column names of the `MatrixTable`.
+
+Note that no copy of the `AbstractMatrix`is made.
 """
-function table(m::AbstractMatrix; header=[Symbol("Column$i") for i = 1:size(m, 2)])
-    symbol_header = header isa Vector{Symbol} ? header : [Symbol(h) for h in header]
-    if length(symbol_header) != size(m, 2)
+function table(matrix::AbstractMatrix; header=[Symbol("Column$i") for i = 1:size(m, 2)], reuse_header=false)
+    if header isa Vector{Symbol} && reuse_header
+	symbol_header = header
+    else
+	symbol_header = [Symbol(h) for h in header]
+    end	
+    if length(symbol_header) != size(matrix, 2)
         throw(ArgumentError("provided column names `header` length must match number of columns in matrix ($(size(m, 2)))"))
     end
     lookup = Dict(nm=>i for (i, nm) in enumerate(symbol_header))
-    return MatrixTable(symbol_header, lookup, m)
+    return MatrixTable(symbol_header, lookup, matrix)
 end
 
 """

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -52,7 +52,7 @@ Tables.jl interface. This allows accessing the matrix via `Tables.rows` and `Tab
 - `matrix::AbstractMatrix`: The matrix to be wrapped in a `MatrixTable`.
 
 # Keywords
-- `header::Any=[Symbol("Column$i") for i = 1:size(matrix, 2)]`: An iterator(e.g `Tuple` or `AbstractVector`) 
+- `header=[Symbol("Column$i") for i = 1:size(matrix, 2)]`: An iterator (`Tuple`, `AbstractVector` etc.) 
     to be used as the column names in  the `MatrixTable`.
 - `reuse_header::Bool=true`: if set to `false` and `header::Vector{Symbol}` then the `header` passed is re-used 
     as the column names of the `MatrixTable` else a freshly allocated `Vector{Symbol}` object derived from `header` 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -54,7 +54,7 @@ Tables.jl interface. This allows accessing the matrix via `Tables.rows` and `Tab
 # Keywords
 - `header=[Symbol("Column\$i") for i = 1:size(matrix, 2)]`: An iterator (`Tuple`, `AbstractVector` etc.) 
     to be used as the column names in  the `MatrixTable`.
-- `reuse_header::Bool=true`: if set to `false` and `header::Vector{Symbol}` then the `header` passed is re-used 
+- `reuse_header::Bool=false`: if set to `true` and `header::Vector{Symbol}` then the `header` passed is re-used 
     as the column names of the `MatrixTable` else a freshly allocated `Vector{Symbol}` object derived from `header` 
     is used as the column names of the `MatrixTable`.
 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -52,7 +52,7 @@ Tables.jl interface. This allows accessing the matrix via `Tables.rows` and `Tab
 - `matrix::AbstractMatrix`: The matrix to be wrapped in a `MatrixTable`.
 
 # Keywords
-- `header=[Symbol("Column$i") for i = 1:size(matrix, 2)]`: An iterator (`Tuple`, `AbstractVector` etc.) 
+- `header=[Symbol("Column\$i") for i = 1:size(matrix, 2)]`: An iterator (`Tuple`, `AbstractVector` etc.) 
     to be used as the column names in  the `MatrixTable`.
 - `reuse_header::Bool=true`: if set to `false` and `header::Vector{Symbol}` then the `header` passed is re-used 
     as the column names of the `MatrixTable` else a freshly allocated `Vector{Symbol}` object derived from `header` 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,8 +240,10 @@ end
     @test Tables.getcolumn(matrow, 1) == 1
     @test propertynames(mattbl) == propertynames(matrow) == [:Column1, :Column2, :Column3]
 
-    mattbl = Tables.table(mat, header=[:A, :B, :C])
+    mattbl = Tables.table(mat, header=[:A, :B, :C], reuse_header=false)
+    mattb2 = Tables.table(mat, header=[:A, :B, :C], reuse_header=true)
     @test Tables.columnnames(mattbl) == [:A, :B, :C]
+    @test Tables.columnnames(mattb2) === [:A, :B, :C]
     mattbl = Tables.table(mat, header=view(["DUMMY", "A", "B", "C"], 2:4))
     @test Tables.columnnames(mattbl) == [:A, :B, :C]
     mattbl = Tables.table(mat, header=(["DUMMY", "A", "B", "C"][i] for i in 2:4))


### PR DESCRIPTION
This PR let's the user decide whether or not they wish to reallocate `header` passed to `table` method. This is done by the introduction of `reuse_header` keyword. 
At **MLJ's** we usually pass `header::Vector{Symbol}` to the `table` method quite often and we wouldn't want that to be reallocated 

@quinnj  @bkamins thoughts?