### PR TITLE
For Tables.columns fallback, attempt to preserve schema on empty inputs

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -174,7 +174,7 @@ Base.isempty(r::RorC) = length(r) == 0
 
 function Base.NamedTuple(r::RorC)
     names = columnnames(r)
-    return NamedTuple{Tuple(names)}(Tuple(getcolumn(r, nm) for nm in names))
+    return NamedTuple{Tuple(Base.map(Symbol, names))}(Tuple(getcolumn(r, nm) for nm in names))
 end
 
 function Base.show(io::IO, x::T) where {T <: RorC}

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -183,7 +183,18 @@ end
 # when Tables.schema(x) === nothing
 @inline function buildcolumns(::Nothing, rowitr::T) where {T}
     state = iterate(rowitr)
-    state === nothing && return NamedTuple()
+    if state === nothing
+        # empty input iterator; check if it has eltype and maybe we can return a better typed empty NamedTuple
+        if Base.IteratorEltype(rowitr) == Base.HasEltype()
+            WT = wrappedtype(eltype(rowitr))
+            if WT <: Tuple
+                return allocatecolumns(Schema((Symbol("Column$i") for i = 1:fieldcount(WT)), fieldtypes(WT)), 0)
+            elseif fieldcount(WT) > 0
+                return allocatecolumns(Schema(fieldnames(WT), fieldtypes(WT)), 0)
+            end
+        end
+        return NamedTuple()
+    end
     row, st = state
     names = Tuple(columnnames(row))
     len = Base.haslength(T) ? length(rowitr) : 0

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -180,7 +180,7 @@ function _buildcolumns(rowitr, row, st, sch, columns, updated)
     return __buildcolumns(rowitr, st, sch, updated[], 1, updated)
 end
 
-if defined(Base, :fieldtypes)
+if isdefined(Base, :fieldtypes)
     _fieldtypes = fieldtypes
 else
     _fieldtypes(T) = (fieldtype(T, i) for i = 1:fieldcount(T))

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -180,6 +180,12 @@ function _buildcolumns(rowitr, row, st, sch, columns, updated)
     return __buildcolumns(rowitr, st, sch, updated[], 1, updated)
 end
 
+if defined(Base, :fieldtypes)
+    _fieldtypes = fieldtypes
+else
+    _fieldtypes(T) = (fieldtype(T, i) for i = 1:fieldcount(T))
+end
+
 # when Tables.schema(x) === nothing
 @inline function buildcolumns(::Nothing, rowitr::T) where {T}
     state = iterate(rowitr)
@@ -188,9 +194,9 @@ end
         if Base.IteratorEltype(rowitr) == Base.HasEltype()
             WT = wrappedtype(eltype(rowitr))
             if WT <: Tuple
-                return allocatecolumns(Schema((Symbol("Column$i") for i = 1:fieldcount(WT)), fieldtypes(WT)), 0)
+                return allocatecolumns(Schema((Symbol("Column$i") for i = 1:fieldcount(WT)), _fieldtypes(WT)), 0)
             elseif fieldcount(WT) > 0
-                return allocatecolumns(Schema(fieldnames(WT), fieldtypes(WT)), 0)
+                return allocatecolumns(Schema(fieldnames(WT), _fieldtypes(WT)), 0)
             end
         end
         return NamedTuple()

--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -61,6 +61,7 @@ struct IteratorRow{T} <: AbstractRow
 end
 
 getrow(r::IteratorRow) = getfield(r, :row)
+wrappedtype(::Type{IteratorRow{T}}) where {T} = T
 
 unwrap(::Type{T}, x) where {T} = convert(T, x)
 unwrap(::Type{Any}, x) = x.hasvalue ? x.value : missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -357,7 +357,7 @@ end
     @test Tables.schema(t) == Tables.Schema((:a, :b, :c), (Int, Float64, String))
     rows = Tuple{Int64, Float64, String}[]
     t = Tables.columns(rows)
-    @test Tables.schema(t) == Tables.Schema((:Column1, :Column2, :Column3), (Int, Float64, String))
+    @test Tables.schema(t) == Tables.Schema((:Column1, :Column2, :Column3), (Int64, Float64, String))
 end
 
 @testset "isless" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,6 +347,17 @@ end
 
     @test_throws ArgumentError Tables.columns(Int64)
     @test_throws ArgumentError Tables.rows(Int64)
+
+    # 204
+    rows = NamedTuple{(:a, :b), Tuple{Int64, Float64}}[]
+    t = Tables.columns(rows)
+    @test Tables.schema(t) == Tables.Schema((:a, :b), (Int64, Float64))
+    rows = GenericRow[]
+    t = Tables.columns(rows)
+    @test Tables.schema(t) == Tables.Schema((:a, :b, :c), (Int, Float64, String))
+    rows = Tuple{Int64, Float64, String}[]
+    t = Tables.columns(rows)
+    @test Tables.schema(t) == Tables.Schema((:Column1, :Column2, :Column3), (Int, Float64, String))
 end
 
 @testset "isless" begin


### PR DESCRIPTION
Fixes #204. For empty row interator inputs, we were just returning an
empty `NamedTuple`. This has the disadvantage of not preserving an
input's schema in the case like `NamedTuple{(:a, :b), Tuple{Int64,
Float64}}[]`. Sometimes the input may be empty, but have a queryable
schema, so we should try to preserve that. For `Tuple` rows, we generate
column names like `Column$i`. I think this is fine because we're in the
fallback `buildcolumns` code where we just want to return a standard
"table" object, so returning a NamedTuple instead of `Tuple` of vectors
seems more appropriate; i.e. it's Tables.jl job here to "build the
columns", so we have latitude and control over what we return.