### PR TITLE
Introduce a specialization threshold and try to avoid generated code

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -517,6 +517,8 @@ Base.length(x::Partitioner) = length(x.x)
 Base.size(x::Partitioner) = size(x.x)
 Base.iterate(x::Partitioner, st...) = iterate(x.x, st...)
 
+const SPECIALIZATION_THRESHOLD = 100
+
 # helper functions
 include("utils.jl")
 

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -106,10 +106,18 @@ Alternatively, and more generally, custom scalars can overload `DataAPI.defaulta
 """
 allocatecolumn(T, len) = DataAPI.defaultarray(T, 1)(undef, len)
 
-@inline function allocatecolumns(::Schema{names, types}, len) where {names, types}
+@inline function _allocatecolumns(::Schema{names, types}, len) where {names, types}
     if @generated
         vals = Tuple(:(allocatecolumn($(fieldtype(types, i)), len)) for i = 1:fieldcount(types))
         return :(NamedTuple{Base.map(Symbol, names)}(($(vals...),)))
+    else
+        return NamedTuple{Base.map(Symbol, names)}(Tuple(allocatecolumn(fieldtype(types, i), len) for i = 1:fieldcount(types)))
+    end
+end
+
+@inline function allocatecolumns(sch::Schema{names, types}, len) where {names, types}
+    if fieldcount(types) <= SPECIALIZATION_THRESHOLD
+        return _allocatecolumns(sch, len)
     else
         return NamedTuple{Base.map(Symbol, names)}(Tuple(allocatecolumn(fieldtype(types, i), len) for i = 1:fieldcount(types)))
     end

--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -104,6 +104,7 @@ Base.length(rows::DataValueRowIterator) = length(rows.x)
 Base.size(rows::DataValueRowIterator) = size(rows.x)
 
 function Base.iterate(rows::DataValueRowIterator{NamedTuple{names, dtypes}, Schema{names, rtypes}, S}, st=()) where {names, dtypes, rtypes, S}
+    # use of @generated justified here because Queryverse has stated only support for "reasonable amount of columns"
     if @generated
         vals = Any[ :(convert($(fieldtype(dtypes, i)), getcolumn(row, $(fieldtype(rtypes, i)), $i, $(Meta.QuoteNode(names[i]))))) for i = 1:length(names) ]
         ret = Expr(:new, :(NamedTuple{names, dtypes}), vals...)


### PR DESCRIPTION
Vastly improves #209. I actually thought this would trip us up sooner,
but kind of forgot about it. We had some generous use of `@generated`
code in a number of places, most aggregiously in
`Tables.allocatecolumns` and `Tables.eachcolumn`. It simplifies the code
to either just use a slow fallback, or skip the generated code entirely
by using macro expansion up to a certain limit. I tried to test out a
number of cases, comparing time to compile vs. resulting compiled code
performance, but it can be tricky to cover a wide variety of workflows.
I might try to generate a wider variety to compare benchmarks pre/post
this PR.