### PR TITLE
Add dictcolumntable and dictrowtable functions

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -204,6 +204,8 @@ Tables.partitions
 Tables.partitioner
 Tables.rowtable
 Tables.columntable
+Tables.dictrowtable
+Tables.dictcolumntable
 Tables.namedtupleiterator
 Tables.datavaluerows
 Tables.nondatavaluerows

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -534,6 +534,9 @@ include("tofromdatavalues.jl")
 # matrix integration
 include("matrix.jl")
 
+# dict tables
+include("dicts.jl")
+
 """
     Tables.columnindex(table, name::Symbol)
 

--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -1,0 +1,179 @@
+struct DictColumnTable <: AbstractColumns
+    schema::Schema
+    values::Dict{Symbol, AbstractVector}
+end
+
+"""
+    Tables.dictcolumntable(x) => Tables.DictColumnTable
+
+Take any Tables.jl-compatible source `x` and return a `DictColumnTable`, which
+can be thought of as a `Dict` mapping column names as `Symbol`s to `AbstractVector`s.
+The order of the input table columns is preserved via the `Tables.schema(::DictColumnTable)`.
+
+For "schema-less" input tables, `dictcolumntable` employs a "column unioning" behavior,
+as opposed to inferring the schema from the first row like `Tables.columns`. This
+means that as rows are iterated, each value from the row is joined into an aggregate
+final set of columns. This is especially useful when input table rows may not include
+columns if the value is missing, instead of including an actual value `missing`, which
+is common in json, for example. This results in a performance cost tracking all seen
+values and inferring the final unioned schemas, so it's recommended to use only when
+needed.
+"""
+function dictcolumntable(x)
+    if columnaccess(x)
+        cols = columns(x)
+        names = columnnames(cols)
+        sch = schema(cols)
+        out = Dict(nm => getcolumn(cols, nm) for nm in names)
+    else
+        r = rows(x)
+        L = Base.IteratorSize(typeof(r))
+        len = Base.haslength(r) ? length(r) : 0
+        sch = schema(r)
+        if sch !== nothing
+            names, types = sch.names, sch.types
+            out = Dict{Int, AbstractVector}(i => allocatecolumn(types[i], len) for i = 1:length(types))
+            for (i, row) in enumerate(r)
+                eachcolumns(add!, sch, row, out, L, i)
+            end
+            out = Dict(names[k] => v for (k, v) in out)
+        else
+            names = Symbol[]
+            seen = Set{Symbol}()
+            out = Dict{Symbol, AbstractVector}()
+            for (i, row) in enumerate(r)
+                for nm in columnnames(row)
+                    push!(seen, nm)
+                    val = getcolumn(row, nm)
+                    if haskey(out, nm)
+                        col = out[nm]
+                        if typeof(val) <: eltype(col)
+                            add!(val, 0, nm, col, L, i)
+                        else # widen column type
+                            new = allocatecolumn(promote_type(eltype(col), typeof(val)), length(col))
+                            i > 1 && copyto!(new, 1, col, 1, i - 1)
+                            add!(new, val, L, i)
+                            out[nm] = new
+                        end
+                    else
+                        push!(names, nm)
+                        if i == 1
+                            new = allocatecolumn(typeof(val), len)
+                            add!(new, val, L, i)
+                            out[nm] = new
+                        else
+                            new = allocatecolumn(Union{Missing, typeof(val)}, len)
+                            add!(new, val, L, i)
+                            out[nm] = new
+                        end
+                    end
+                end
+                for nm in names
+                    if !(nm in seen)
+                        col = out[nm]
+                        if !(eltype(col) >: Missing)
+                            new = allocatecolumn(Union{Missing, eltype(col)}, len)
+                            i > 1 && copyto!(new, 1, col, 1, i - 1)
+                            out[nm] = new
+                        end
+                    end
+                end
+                empty!(seen)
+            end
+            sch = Schema(collect(keys(out)), eltype.(values(out)))
+        end
+    end
+    return DictColumnTable(sch, out)
+end
+
+istable(::Type{DictColumnTable}) = true
+columnaccess(::Type{DictColumnTable}) = true
+columns(x::DictColumnTable) = x
+schema(x::DictColumnTable) = getfield(x, :schema)
+columnnames(x::DictColumnTable) = getfield(x, :schema).names
+getcolumn(x::DictColumnTable, i::Int) = getfield(x, :values)[columnnames(x)[i]]
+getcolumn(x::DictColumnTable, nm::Symbol) = getfield(x, :values)[nm]
+
+struct DictRowTable
+    names::Vector{Symbol}
+    types::Dict{Symbol, Type}
+    values::Vector{Dict{Symbol, Any}}
+end
+
+isrowtable(::Type{DictRowTable}) = true
+schema(x::DictRowTable) = Schema(getfield(x, :names), values(getfield(x, :types)))
+
+struct DictRow <: AbstractRow
+    names::Vector{Symbol}
+    row::Dict{Symbol, Any}
+end
+
+columnnames(x::DictRow) = getfield(x, :names)
+getcolumn(x::DictRow, i::Int) = get(getfield(x, :row), columnnames(x)[i], missing)
+getcolumn(x::DictRow, nm::Symbol) = get(getfield(x, :row), nm, missing)
+
+Base.IteratorSize(::Type{DictRowTable}) = Base.HasLength()
+Base.length(x::DictRowTable) = length(getfield(x, :values))
+Base.IteratorEltype(::Type{DictRowTable}) = Base.HasEltype()
+Base.eltype(x::DictRowTable) = DictRow
+
+function Base.iterate(x::DictRowTable, st=1)
+    st > length(x) && return nothing
+    return DictRow(x.names, x.values[st]), st + 1
+end
+
+"""
+    Tables.dictrowtable(x) => Tables.DictRowTable
+
+Take any Tables.jl-compatible source `x` and return a `DictRowTable`, which
+can be thought of as a `Vector` of `Dict` rows mapping column names as `Symbol`s to values.
+The order of the input table columns is preserved via the `Tables.schema(::DictRowTable)`.
+
+For "schema-less" input tables, `dictrowtable` employs a "column unioning" behavior,
+as opposed to inferring the schema from the first row like `Tables.columns`. This
+means that as rows are iterated, each value from the row is joined into an aggregate
+final set of columns. This is especially useful when input table rows may not include
+columns if the value is missing, instead of including an actual value `missing`, which
+is common in json, for example. This results in a performance cost tracking all seen
+values and inferring the final unioned schemas, so it's recommended to use only when
+the union behavior is needed.
+"""
+function dictrowtable(x)
+    names = Symbol[]
+    seen = Set{Symbol}()
+    types = Dict{Symbol, Type}()
+    r = rows(x)
+    L = Base.IteratorSize(typeof(r))
+    out = Vector{Dict{Symbol, Any}}(undef, Base.haslength(r) ? length(r) : 0)
+    for (i, drow) in enumerate(x)
+        row = Dict{Symbol, Any}(nm => getcolumn(drow, nm) for nm in columnnames(drow))
+        add!(row, 0, :_, out, L, i)
+        if isempty(names)
+            for (k, v) in row
+                push!(names, k)
+                types[k] = typeof(v)
+            end
+            seen = Set(names)
+        else
+            for nm in names
+                if haskey(row, nm)
+                    T = types[nm]
+                    v = row[nm]
+                    if !(typeof(v) <: T)
+                        types[nm] = Union{T, typeof(v)}
+                    end
+                else
+                    types[nm] = Union{Missing, types[nm]}
+                end
+            end
+            for (k, v) in row
+                if !(k in seen)
+                    push!(seen, k)
+                    push!(names, k)
+                    types[k] = typeof(v)
+                end
+            end
+        end
+    end
+    return DictRowTable(names, types, out)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -635,16 +635,16 @@ end
 
     drt = Tables.dictrowtable(rt)
     @test length(drt) == 5
-    @test Tables.schema(drt).names == (:a, :b, :c, :d)
-    @test Tables.schema(drt).types == (Union{Int, Missing}, Union{Int, Float64, Missing}, Union{Int, Missing}, Union{Int, Missing})
     ct = Tables.columntable(drt)
     @test isequal(ct.a, [1, missing, 6, 8, 8])
+    @test isequal(ct.b, Union{Int, Float64, Missing}[2, 4.1, missing, 9, 9])
+    @test isequal(ct.c, [3, missing, missing, 10, 10])
     @test isequal(ct.d, [missing, 5, 7, missing, 11])
 
     dct = Tables.dictcolumntable(rt)
-    @test Tables.schema(drt).names == (:a, :b, :c, :d)
-    @test Tables.schema(drt).types == (Union{Int, Missing}, Union{Int, Float64, Missing}, Union{Int, Missing}, Union{Int, Missing})
     @test isequal(dct.a, [1, missing, 6, 8, 8])
+    @test isequal(ct.b, Union{Int, Float64, Missing}[2, 4.1, missing, 9, 9])
+    @test isequal(ct.c, [3, missing, missing, 10, 10])
     @test isequal(dct.d, [missing, 5, 7, missing, 11])
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -627,7 +627,7 @@ end
 
     rt = [
         (a=1, b=2, c=3),
-        (b=4.1, c=missing, d=5),
+        (b=4.0, c=missing, d=5),
         (a=6, d=7),
         (a=8, b=9, c=10, d=missing),
         (d=11, c=10, b=9, a=8)
@@ -637,13 +637,13 @@ end
     @test length(drt) == 5
     ct = Tables.columntable(drt)
     @test isequal(ct.a, [1, missing, 6, 8, 8])
-    @test isequal(ct.b, Union{Int, Float64, Missing}[2, 4.1, missing, 9, 9])
+    @test isequal(ct.b, Union{Int, Float64, Missing}[2, 4.0, missing, 9, 9])
     @test isequal(ct.c, [3, missing, missing, 10, 10])
     @test isequal(ct.d, [missing, 5, 7, missing, 11])
 
     dct = Tables.dictcolumntable(rt)
     @test isequal(dct.a, [1, missing, 6, 8, 8])
-    @test isequal(ct.b, Union{Int, Float64, Missing}[2, 4.1, missing, 9, 9])
+    @test isequal(ct.b, Union{Int, Float64, Missing}[2, 4.0, missing, 9, 9])
     @test isequal(ct.c, [3, missing, missing, 10, 10])
     @test isequal(dct.d, [missing, 5, 7, missing, 11])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -591,3 +591,60 @@ end
     end
 
 end
+
+@testset "Dict tables" begin
+
+    rt = [(a=1, b=4.0, c="7"), (a=2, b=5.0, c="8"), (a=3, b=6.0, c="9")]
+    ct = (a=[1, 2, 3], b=[4.0, 5.0, 6.0], c=["7", "8", "9"])
+
+    dct = Tables.dictcolumntable(rt)
+    @test Tables.istable(dct)
+    @test Tables.columnaccess(dct)
+    @test Tables.columns(dct) === dct
+    @test Tables.schema(dct) == Tables.Schema((:a, :b, :c), (Int, Float64, String))
+    @test dct.a == [1, 2, 3]
+    @test dct.b == [4.0, 5.0, 6.0]
+    @test dct.c == ["7", "8", "9"]
+    
+    dct = Tables.dictcolumntable(ct)
+    @test dct.a == [1, 2, 3]
+    @test dct.b == [4.0, 5.0, 6.0]
+    @test dct.c == ["7", "8", "9"]
+    cct = Tables.columntable(dct)
+    @test cct.a == [1, 2, 3]
+    @test cct.b == [4.0, 5.0, 6.0]
+    @test cct.c == ["7", "8", "9"]
+
+    drt = Tables.dictrowtable(rt)
+    @test Tables.isrowtable(drt)
+    @test Tables.schema(drt) == Tables.Schema((:a, :b, :c), (Int, Float64, String))
+    row = first(drt)
+    @test (row.a, row.b, row.c) == (1, 4.0, "7")
+    cct = Tables.columntable(drt)
+    @test cct.a == [1, 2, 3]
+    @test cct.b == [4.0, 5.0, 6.0]
+    @test cct.c == ["7", "8", "9"]
+
+    rt = [
+        (a=1, b=2, c=3),
+        (b=4.1, c=missing, d=5),
+        (a=6, d=7),
+        (a=8, b=9, c=10, d=missing),
+        (d=11, c=10, b=9, a=8)
+    ]
+
+    drt = Tables.dictrowtable(rt)
+    @test length(drt) == 5
+    @test Tables.schema(drt).names == (:a, :b, :c, :d)
+    @test Tables.schema(drt).types == (Union{Int, Missing}, Union{Int, Float64, Missing}, Union{Int, Missing}, Union{Int, Missing})
+    ct = Tables.columntable(drt)
+    @test isequal(ct.a, [1, missing, 6, 8, 8])
+    @test isequal(ct.d, [missing, 5, 7, missing, 11])
+
+    dct = Tables.dictcolumntable(rt)
+    @test Tables.schema(drt).names == (:a, :b, :c, :d)
+    @test Tables.schema(drt).types == (Union{Int, Missing}, Union{Int, Float64, Missing}, Union{Int, Missing}, Union{Int, Missing})
+    @test isequal(dct.a, [1, missing, 6, 8, 8])
+    @test isequal(dct.d, [missing, 5, 7, missing, 11])
+
+end


### PR DESCRIPTION
Fixes #161 and #207. This defines two table types, `DictColumnTable` and
`DictRowTable`, along wtih corresponding constructors, `dictcolumntable`
and `dictrowtable`. For #161, both table types hold their own schema,
which provides a way to specify the "ordering" of the tables, even
though the underlying data is stored in `Dict`s. For #207, both these
table types employ a "column unioning" approach for schema-less input
row iterators. This is similar to the `cols=:union` behavior you get
with DataFrames `push!`, and at least provides a way for users to get
this behavior when so desired. I like this approach because to even
implement the functionality, you basically need to treat rows/columns as
`Dict`s, to check if keys are present or not, and they're very flexible
in terms of adding additional key-value pairs (much easier than trying
to "update" `NamedTuple`s). So this is a bit of a compromise: we keep
the current great performance of `Tables.columns` fallback via
`Tables.buildcolumns` for schema-less row iterator inputs, but provide a
pretty simple "intermediate" table type that will union columns if
needed, via `dictcolumntable` and `dictrowtable`.