### PR TITLE
Define a generic fallback for wrappedtype function

### DIFF
--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -62,6 +62,7 @@ end
 
 getrow(r::IteratorRow) = getfield(r, :row)
 wrappedtype(::Type{IteratorRow{T}}) where {T} = T
+wrappedtype(::Type{T}) where {T} = T
 
 unwrap(::Type{T}, x) where {T} = convert(T, x)
 unwrap(::Type{Any}, x) = x.hasvalue ? x.value : missing


### PR DESCRIPTION
Fixes https://github.com/JuliaDatabases/SQLite.jl/issues/220. One of the
issues that was fixed in 1.2 is that for the empty iterator case, we try
to still determine if we can produce a "typed" output, if the input has
a "schema". I wrongly assumed that `rowitr` in this, empty, schema-less
branch of code would always be `IteratorWrapper`, and thus only defined
`wrappedtype` on it, with no fallback. This lead to the issue in
https://github.com/JuliaDatabases/SQLite.jl/issues/220 where
`SQLite.Query` is "schema"-less, but defines `Tables.rowaccess` and
`Tables.rows`, and might be empty. This lead to the method error. The
fix is pretty easy here: just define a fallback for `wrappedtype`.