### PR TITLE
Add `namedtupleiterator`/`rowtable` docs cross-ref

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -356,6 +356,8 @@ which may return `nothing` if the schema is unknown.
 Column names can always be queried by calling `Tables.columnnames(row)` on an individual row,
 and row values can be accessed by calling `Tables.getcolumn(rows, i::Int )` or
 `Tables.getcolumn(rows, nm::Symbol)` with a column index or name, respectively.
+
+See also [`rowtable`](@ref) and [`namedtupleiterator`](@ref).
 """
 function rows end
 

--- a/src/namedtuples.jl
+++ b/src/namedtuples.jl
@@ -16,7 +16,7 @@ end
 
 Pass any table input source and return a `NamedTuple` iterator
 
-See also [`rowtable`](@ref).
+See also [`rows`](@ref) and [`rowtable`](@ref).
 """
 function namedtupleiterator(x)
     r = rows(x)
@@ -90,7 +90,7 @@ naturally, i.e. a `Vector` naturally iterates its elements, and
 `NamedTuple` satisifes the `AbstractRow` interface by default (allows
 indexing value by index, name, and getting all names).
 
-For a lazy iterator over rows see [`namedtupleiterator`](@ref).
+For a lazy iterator over rows see [`rows`](@ref) and [`namedtupleiterator`](@ref).
 """
 function rowtable end
 

--- a/src/namedtuples.jl
+++ b/src/namedtuples.jl
@@ -15,6 +15,8 @@ end
     Tables.namedtupleiterator(x)
 
 Pass any table input source and return a `NamedTuple` iterator
+
+See also [`rowtable`](@ref).
 """
 function namedtupleiterator(x)
     r = rows(x)
@@ -87,6 +89,8 @@ table type of sorts, since it satisfies the Tables.jl row interface
 naturally, i.e. a `Vector` naturally iterates its elements, and
 `NamedTuple` satisifes the `AbstractRow` interface by default (allows
 indexing value by index, name, and getting all names).
+
+For a lazy iterator over rows see [`namedtupleiterator`](@ref).
 """
 function rowtable end
 


### PR DESCRIPTION
Attempts to makes `namedtupleiterator` a little more discoverable :) 

~(Aside: would it be more discoverable if renamed `rowiterator`? especially if there were a `columniterator` too? https://github.com/JuliaData/Tables.jl/issues/149.)~ Edit: no, since `RowIterator` is a different thing. Ignore that. 😆 Added xrefs to `rows` too.