### PR TITLE
getcolumn on MatrixTable now returns views

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -37,9 +37,9 @@ Base.iterate(m::MatrixTable, st=1) = st > length(m) ? nothing : (MatrixRow(st, m
 Columns(m::T) where {T <: MatrixTable} = Columns{T}(m)
 columnaccess(::Type{<:MatrixTable}) = true
 columns(m::MatrixTable) = m
-getcolumn(m::MatrixTable, ::Type{T}, col::Int, nm::Symbol) where {T} = getfield(m, :matrix)[:, col]
-getcolumn(m::MatrixTable, nm::Symbol) = getfield(m, :matrix)[:, getfield(m, :lookup)[nm]]
-getcolumn(m::MatrixTable, i::Int) = getfield(m, :matrix)[:, i]
+getcolumn(m::MatrixTable, i::Int) = view(getfield(m, :matrix), :, i)
+getcolumn(m::MatrixTable, ::Type, col::Int, nm::Symbol) = getcolumn(m, col)
+getcolumn(m::MatrixTable, nm::Symbol) = getcolumn(m, getfield(m, :lookup)[nm])
 columnnames(m::MatrixTable) = names(m)
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,6 +250,13 @@ end
     @test Tables.columnnames(mattbl) == Symbol.(1:3)
     @test_throws ArgumentError Tables.table(mat, header=[:A, :B, :C, :D])
 
+    X = [1 2; 3 4; 5 6]
+    tbl = Tables.table(X)
+    tbl[1][1] = 100
+    @test X[1, 1] == 100
+    tbl[2][3] = 200
+    @test X[3, 2] == 200
+
     # #155
     m = hcat([1,2,3],[1,2,3])
     T = Tables.table(m)


### PR DESCRIPTION
This fixes an issue in which the behavior of `MatrixTable` was inconsistent with that of other tables because `getcolumn` (and therefore indexing) was returning copies instead of views.

Technically this is breaking, even though I think it's fair to say the previous behavior was a bug, so hopefully 1.2.2 will be an acceptable tag for this.