### PR TITLE
improved behavior of Tables.Columns

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.2.3"
+version = "1.3.0"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -243,7 +243,6 @@ struct Columns{T} <: AbstractColumns
     x::T
 end
 
-Columns(x) = Columns{typeof(x)}(x)
 Columns(x::AbstractColumns) = x
 
 # Columns can only wrap something that is a table, so we pass the schema through

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -241,9 +241,17 @@ to provide useful default behaviors (allows any `AbstractColumns` to be used lik
 """
 struct Columns{T} <: AbstractColumns
     x::T
+
+    function Columns{T}(x::T) where {T}
+        istable(x) ? new{T}(x) : throw(ArgumentError("Columns can only wrap an object for which `Tables.istable` is true"))
+    end
 end
 
+Columns(x) = Columns{typeof(x)}(x)
 Columns(x::AbstractColumns) = x
+
+# Columns can only wrap something that is a table, so we pass the schema through
+schema(x::Columns) = schema(getx(x))
 
 const RorC2 = Union{Row, Columns}
 

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -241,10 +241,6 @@ to provide useful default behaviors (allows any `AbstractColumns` to be used lik
 """
 struct Columns{T} <: AbstractColumns
     x::T
-
-    function Columns{T}(x::T) where {T}
-        istable(x) ? new{T}(x) : throw(ArgumentError("Columns can only wrap an object for which `Tables.istable` is true"))
-    end
 end
 
 Columns(x) = Columns{typeof(x)}(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -582,7 +582,6 @@ end
 @testset "Tables.Columns" begin
     X = (A=[1,2], B=[im, -im], C=["kirk", "spock"])
 
-    @test_throws ArgumentError("Columns can only wrap an object for which `Tables.istable` is true") Tables.Columns(nothing)
     Xc = Tables.Columns(X)
     @test Tables.schema(X) == Tables.schema(Xc)
     for i ∈ 1:3


### PR DESCRIPTION
This PR fixes a few odd loopholes in the behavior of `Tables.Columns`.

First, we now check if the argument to `Tables.Columns` is itself a table.  It took me a little while to convince myself that this indeed must be the case, but once I did, I realized the current behavior is permissive of some pretty strange things.  For example
```julia
Tables.Columns(nothing)
```
returns a perfectly valid (albeit empty) table.  To check for this we of course have to sacrifice `Tables.Columns` being a no-op, but this seems like a pretty small sacrifice to sanitize the behavior.

Second, `Tables.Columns` did not itself have a definition for `Tables.schema`, which meant that `Tables.Columns` itself was actually broken for much of the Tables.jl interface.  Again, since it can only wrap a table, I simply take the schema of the object it wraps.  Technically `Tables.AbstractColumns` should probably have a fallback of `Tables.schema`, however, since this cannot infer the types, it seems pretty useless in practice so I left it alone.

I have added unit tests for the above, as well as some unit tests making sure matrices cooperate nicely with `Tables.Columns` (I started uncovering these issues when trying to wrap a table in `Tables.Columns` that was originally derived from a matrix.)

I've also taken the liberty of changing the name of the `Columns` struct in `runtests.jl` to `TestColumns`, as I initially found the name shadowing confusing.