### PR TITLE
Fix fallback case on empty input iterators with abstract eltypes

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -203,7 +203,7 @@ end
             WT = wrappedtype(eltype(rowitr))
             if WT <: Tuple
                 return allocatecolumns(Schema((Symbol("Column$i") for i = 1:fieldcount(WT)), _fieldtypes(WT)), 0)
-            elseif fieldcount(WT) > 0
+            elseif isconcretetype(WT) && fieldcount(WT) > 0
                 return allocatecolumns(Schema(fieldnames(WT), _fieldtypes(WT)), 0)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,6 +169,9 @@ end
     @test eltype(rt).parameters[1] == nms
     @test Tables.columntable(rt) == nt
     @test Tables.buildcolumns(nothing, rt) == nt
+
+    # 228
+    @test Tables.columntable(NamedTuple[]) === NamedTuple()
 end
 
 @testset "Materializer" begin


### PR DESCRIPTION
Fixes #228. We recently added support so that when a schema-less input
row table was being converted to column-orientation, but had an eltype,
we produced an appropriately typed NamedTuple with empty Vectors of
corresponding types. The issue reported, however, is when an empty input
has an eltype, but that eltype is abstract. The error results by trying
to call `fieldcount(::AbstractType)`, which fails and doesn't make sense
to do anyway. This is technically a regression because we used to
produce an empty `NamedTuple()` unconditionally, and now we're producing
this error path for the abstract eltype case. The fix proposed is
straightforward: only consider generating a typed NamedTuple output if
the iterator eltype is concretely typed.