### PR TITLE
Improve widening check for non-schema column building

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -143,7 +143,7 @@ end
 replacex(t, col::Int, x) = ntuple(i->i == col ? x : t[i], length(t))
 
 @inline function add_or_widen!(val, col::Int, nm, dest::AbstractArray{T}, row, updated, L) where {T}
-    if val isa T
+    if val isa T || promote_type(typeof(val), T) <: T
         add!(dest, val, L, row)
         return
     else


### PR DESCRIPTION
The issue here is seen in a simple example where a row-oriented input may have a Float64 element early on, but Int64 elements afterwards. For those Int64 elements, the `val isa T` check fails, which leads to the code branch where the array is widened using `promote_type(typeof(val), T)` and reallocated. For the case of Int64 and Float64, `promote_type` produces Float64, so the array is reallocated unnecessarily. By instead checking if our `val` to set is _either_ `val isa T || promote_type(typeof(val), T) <: T` then we take the assumption that if `val` promotes to `T` then it can also be converted to `T` on `setindex!`.

This is tricky to test for because there's actually no change in behavior; we're just avoiding a lot of unnecessary array allocating/inefficiencies.