### PR TITLE
add AbstractRow equivalent of Base.merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.3.2"
+version = "1.3.3"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.3.3"
+version = "1.4.0"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -215,6 +215,7 @@ Tables.eachcolumn
 Tables.materializer
 Tables.columnindex
 Tables.columntype
+Tables.rowmerge
 Tables.Row
 Tables.Columns
 ```

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -127,3 +127,22 @@ end
     end
     return
 end
+
+"""
+    with(row; patch...)
+    with(row, patches...)
+
+Return a `NamedTuple` by merging `row` (a `AbstractRow`-compliant value) with `patches` (one or more
+`AbstractRow`-compliant values) via `Base.merge`. In other words, this function is similar to
+`Base.merge(::NamedTuple, ::NamedTuple...)`, but accepts `AbstractRow`-compliant values intead of
+`NamedTuple`s.
+
+A convenience method `with(row; patch...) = with(row, patch)` is defined that enables `patch`
+fields to be specified as keyword arguments.
+"""
+with(row; patch...) = with(row, patch)
+with(row, patch) = merge(_row_to_named_tuple(row), _row_to_named_tuple(patch))
+with(row, patch, more...) = merge(_row_to_named_tuple(row), with(patch, more...))
+
+_row_to_named_tuple(row::NamedTuple) = row
+_row_to_named_tuple(row) = NamedTuple(Row(row))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -129,20 +129,20 @@ end
 end
 
 """
-    with(row; patch...)
-    with(row, patches...)
+    rowmerge(row, other_rows...)
+    rowmerge(row; fields_to_merge...)
 
-Return a `NamedTuple` by merging `row` (a `AbstractRow`-compliant value) with `patches` (one or more
-`AbstractRow`-compliant values) via `Base.merge`. In other words, this function is similar to
-`Base.merge(::NamedTuple, ::NamedTuple...)`, but accepts `AbstractRow`-compliant values intead of
-`NamedTuple`s.
+Return a `NamedTuple` by merging `row` (an `AbstractRow`-compliant value) with `other_rows`
+(one or more `AbstractRow`-compliant values) via `Base.merge`. This function is similar to
+`Base.merge(::NamedTuple, ::NamedTuple...)`, but accepts `AbstractRow`-compliant values
+instead of `NamedTuple`s.
 
-A convenience method `with(row; patch...) = with(row, patch)` is defined that enables `patch`
-fields to be specified as keyword arguments.
+A convenience method `rowmerge(row; fields_to_merge...) = rowmerge(row, fields_to_merge)`
+is defined that enables the `fields_to_merge` to be specified as keyword arguments.
 """
-with(row; patch...) = with(row, patch)
-with(row, patch) = merge(_row_to_named_tuple(row), _row_to_named_tuple(patch))
-with(row, patch, more...) = merge(_row_to_named_tuple(row), with(patch, more...))
+rowmerge(row; fields_to_merge...) = rowmerge(row, fields_to_merge.data)
+rowmerge(row, other) = merge(_row_to_named_tuple(row), _row_to_named_tuple(other))
+rowmerge(row, other, more...) = merge(_row_to_named_tuple(row), rowmerge(other, more...))
 
 _row_to_named_tuple(row::NamedTuple) = row
 _row_to_named_tuple(row) = NamedTuple(Row(row))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -140,7 +140,7 @@ Return a `NamedTuple` by merging `row` (a `AbstractRow`-compliant value) with `p
 A convenience method `with(row; patch...) = with(row, patch)` is defined that enables `patch`
 fields to be specified as keyword arguments.
 """
-with(row; patch...) = with(row, patch)
+with(row; patch...) = with(row, patch.data)
 with(row, patch) = merge(_row_to_named_tuple(row), _row_to_named_tuple(patch))
 with(row, patch, more...) = merge(_row_to_named_tuple(row), with(patch, more...))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,10 @@ using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceEx
     @test Tables.columns(rows) === nt
     @test Tables.materializer(rows) === Tables.materializer(nt)
 
+    @test Tables.with(row; b=200, hey="hello") == (a=1, b=200, hey="hello")
+    @test Tables.with(row, (hey="hello", a=200)) == (a=200, b=4, hey="hello")
+    @test Tables.with(row, (hey="hello", a=200), row, (x=:x, y=:y, hey="bye")) == (a=1, b=4, hey="bye", x=:x, y=:y)
+
     @test Tables.sym(1) === 1
     @test Tables.sym("hey") == :hey
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,9 +84,9 @@ using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceEx
     @test Tables.columns(rows) === nt
     @test Tables.materializer(rows) === Tables.materializer(nt)
 
-    @test Tables.with(row; b=200, hey="hello") == (a=1, b=200, hey="hello")
-    @test Tables.with(row, (hey="hello", a=200)) == (a=200, b=4, hey="hello")
-    @test Tables.with(row, (hey="hello", a=200), row, (x=:x, y=:y, hey="bye")) == (a=1, b=4, hey="bye", x=:x, y=:y)
+    @test Tables.rowmerge(row; b=200, hey="hello") == (a=1, b=200, hey="hello")
+    @test Tables.rowmerge(row, (hey="hello", a=200)) == (a=200, b=4, hey="hello")
+    @test Tables.rowmerge(row, (hey="hello", a=200), row, (x=:x, y=:y, hey="bye")) == (a=1, b=4, hey="bye", x=:x, y=:y)
 
     @test Tables.sym(1) === 1
     @test Tables.sym("hey") == :hey


### PR DESCRIPTION
This tiny utility function kept coming up in Beacon's usage of (self-authored) Tables.jl-compliant interfaces, where functions on row-like values are duck-typed to accept any `AbstractRow`-compliant value. When calling such functions, I find I often want to concisely transform the row at the callsite to patch in a slightly modified field (or set of fields). However, as a caller, I'm also usually manipulating whatever `AbstractRow`-compliant values are passed to me, so I need to ensure my manipulations are sufficiently generic.

Thus, I end up using this little utility in a variety of places. Is there interest in having it live here? If not, I'm sure I can find a different place to put it 😁

If it's a good idea for this to live here, feel free to bikeshed the ridiculously vague name of the function...I have also called it `from` in the past, which isn't any better 😛. I originally called it `mergerows` (after `Base.merge`) but:

1.  `mergerows` sounds like it might be referring to a row-wise reduction on a table (which this is not)
2. I often use it in argument position (e.g. `myfunction(with(row; field=f(row.old)))`), so the conciseness is nice
3. The kwarg form is very convenient, and `Base.merge` doesn't have that form, reducing the resemblance a tad