### PR TITLE
add shorter show method for `AbstractColumns`

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -190,7 +190,7 @@ function Base.NamedTuple(r::RorC)
     return NamedTuple{Tuple(Base.map(Symbol, names))}(Tuple(getcolumn(r, nm) for nm in names))
 end
 
-function Base.show(io::IO, x::T) where {T <: RorC}
+function Base.show(io::IO, x::T) where {T <: AbstractRow}
     if get(io, :compact, false) || get(io, :limit, false)
         print(io, "$T: ")
         show(io, NamedTuple(x))
@@ -199,6 +199,25 @@ function Base.show(io::IO, x::T) where {T <: RorC}
         names = collect(columnnames(x))
         values = [getcolumn(x, nm) for nm in names]
         Base.print_matrix(io, hcat(names, values))
+    end
+end
+
+function Base.show(io::IO, table::AbstractColumns; max_cols = 20)
+    nrows = try
+        string(length(Tables.getcolumn(table, 1)))
+    catch e
+        e isa MethodError || rethrow()
+        "an unknown number of"
+    end
+    cols = Tables.columnnames(table)
+    ncols = length(cols)
+    print(io, "$(typeof(table)) with $(nrows) rows and $(ncols) columns, and ")
+    sch = schema(table)
+    if sch !== nothing
+        print(io, "schema:\n")
+        show(io, sch)
+    else
+        print(io, "an unknown schema.")
     end
 end
 

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -204,11 +204,11 @@ end
 
 function Base.show(io::IO, table::AbstractColumns; max_cols = 20)
     ncols = length(columnnames(table))
-    print(io, "$(typeof(table)) with $(rowcount(table)) rows and $(ncols) columns, and ")
+    print(io, "$(typeof(table)) with $(rowcount(table)) rows, $(ncols) columns, and ")
     sch = schema(table)
     if sch !== nothing
         print(io, "schema:\n")
-        show(io, sch)
+        show(IOContext(io, :print_schema_header => false), sch)
     else
         print(io, "an unknown schema.")
     end
@@ -425,7 +425,7 @@ Schema(names, ::Nothing) = Schema{Tuple(Base.map(sym, names)), nothing}()
 Schema(names, types) = Schema{Tuple(Base.map(sym, names)), Tuple{types...}}()
 
 function Base.show(io::IO, sch::Schema{names, types}) where {names, types}
-    println(io, "Tables.Schema:")
+    get(io, :print_schema_header, true) && println(io, "Tables.Schema:")
     Base.print_matrix(io, hcat(collect(names), types === nothing ? fill(nothing, length(names)) : collect(fieldtype(types, i) for i = 1:fieldcount(types))))
 end
 

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -203,15 +203,8 @@ function Base.show(io::IO, x::T) where {T <: AbstractRow}
 end
 
 function Base.show(io::IO, table::AbstractColumns; max_cols = 20)
-    nrows = try
-        string(length(Tables.getcolumn(table, 1)))
-    catch e
-        e isa MethodError || rethrow()
-        "an unknown number of"
-    end
-    cols = Tables.columnnames(table)
-    ncols = length(cols)
-    print(io, "$(typeof(table)) with $(nrows) rows and $(ncols) columns, and ")
+    ncols = length(columnnames(table))
+    print(io, "$(typeof(table)) with $(rowcount(table)) rows and $(ncols) columns, and ")
     sch = schema(table)
     if sch !== nothing
         print(io, "schema:\n")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -573,6 +573,9 @@ struct DummyCols <: Tables.AbstractColumns end
     @test isequal(collect(col), [[1,2], [missing,3.14], ["hey","ho"]])
     show(col)
 
+    tbl = TestColumns(rand(Int, 100), rand(100), [ "a" for _ = 1:100])
+    @test length(sprint(show, tbl)) < 500
+
     ct = (a=[1, 2], b=[missing, 3.14], c=["hey", "ho"])
     @test Tables.istable(col)
     @test Tables.columnaccess(col)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -601,6 +601,9 @@ end
         @test Tables.getcolumn(X, i) == Tables.getcolumn(Xc, i)
     end
     @test Tables.columnnames(X) == Tables.columnnames(Xc)
+
+    tbl = Tables.Columns((; a=rand(Int, 100), b=rand(100), c=[ "a" for _ = 1:100]))
+    @test length(sprint(show, tbl)) < 500
 end
 
 struct IsRowTable


### PR DESCRIPTION
For example,
```julia
julia> big_tbl = (; a = [rand(100) for _ = 1:200], b = [rand(100) for _ = 1:200], c = [rand(100) for _ = 1:200]);

julia> tbl = Arrow.Table(Arrow.tobuffer(big_tbl))
Arrow.Table with 200 rows, 3 columns, and schema:
 :a  Vector{Float64} (alias for Array{Float64, 1})
 :b  Vector{Float64} (alias for Array{Float64, 1})
 :c  Vector{Float64} (alias for Array{Float64, 1})
```
This table used to print as 1.2M characters! (The “alias” printing is removed with https://github.com/JuliaLang/julia/pull/39256 I believe).

I tried to be pretty safe here since `AbstractColumns` are very general, and I'm not sure if we can expect columns to have a `length` for example.

I decided to print the schema instead of a manual column printing as in https://github.com/JuliaData/Arrow.jl/issues/168, since we don't have the `eltype` info in general (`columntypes` just asks the schema, so the fallback method only works when we have a schema), and I think maybe if Tables doesn't have a schema that can be useful info to pass along to the user (perhaps they can add one and improve performance in some cases).