### PR TITLE
Fix Tables.schema on Tables.DictRowTable

### DIFF
--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -101,7 +101,7 @@ struct DictRowTable
 end
 
 isrowtable(::Type{DictRowTable}) = true
-schema(x::DictRowTable) = Schema(getfield(x, :names), values(getfield(x, :types)))
+schema(x::DictRowTable) = Schema(getfield(x, :names), [getfield(x, :types)[nm] for nm in getfield(x, :names)])
 
 struct DictRow <: AbstractRow
     names::Vector{Symbol}

--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -145,7 +145,7 @@ function dictrowtable(x)
     r = rows(x)
     L = Base.IteratorSize(typeof(r))
     out = Vector{Dict{Symbol, Any}}(undef, Base.haslength(r) ? length(r) : 0)
-    for (i, drow) in enumerate(x)
+    for (i, drow) in enumerate(r)
         row = Dict{Symbol, Any}(nm => getcolumn(drow, nm) for nm in columnnames(drow))
         add!(row, 0, :_, out, L, i)
         if isempty(names)
@@ -170,7 +170,11 @@ function dictrowtable(x)
                 if !(k in seen)
                     push!(seen, k)
                     push!(names, k)
-                    types[k] = typeof(v)
+                    # we mark the type as Union{T, Missing} here because
+                    # we're at least on the 2nd row, and we didn't see
+                    # this column in the 1st row, so its value will be
+                    # `missing` for that row
+                    types[k] = Union{typeof(v), Missing}
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -688,7 +688,7 @@ end
     ]
 
     drt = Tables.dictrowtable(rt)
-    @test Tables.schema(drt) == Tables.Schema((:a, :b, :c, :d), (Union{Missing, Int64}, Union{Missing, Float64, Int64}, Union{Missing, Int64}, Union{Missing, Int64}))
+    @test Tables.schema(drt) == Tables.Schema((:a, :b, :c, :d), (Union{Missing, Int}, Union{Missing, Float64, Int}, Union{Missing, Int}, Union{Missing, Int}))
     @test length(drt) == 5
     ct = Tables.columntable(drt)
     @test isequal(ct.a, [1, missing, 6, 8, 8])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -688,6 +688,7 @@ end
     ]
 
     drt = Tables.dictrowtable(rt)
+    @test Tables.schema(drt) == Tables.Schema((:a, :b, :c, :d), (Union{Missing, Int64}, Union{Missing, Float64, Int64}, Union{Missing, Int64}, Union{Missing, Int64}))
     @test length(drt) == 5
     ct = Tables.columntable(drt)
     @test isequal(ct.a, [1, missing, 6, 8, 8])


### PR DESCRIPTION
Yuck; these kinds of bugs are the worst. Poor original coding (shame on
you past self), and tests that _happened_ to work by coincidence. The
problem here is that by just calling `values(getfield(x, :types))`,
we're just retrieving the types by however `Dict` internals happen to
order them, but in most cases, will _not_ match the order of column
names. We had a test for a simple case like `@test Tables.schema(drt) ==
Tables.Schema((:a, :b, :c), (Int, Float64, String))` that I guess just
happens to maintain the right ordering, even across julia versions. Oh
well, I'm guess that means not a lot of people rely on the exact schema
produced by `Tables.dictrowtable`, if they're even aware it exists and
use it. We probably need to better advertise its functionality.