### PR TITLE
Lower the wide-table specialization threshold by a little

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -443,7 +443,7 @@ sym(x::Int) = x
 
 Schema(names, ::Nothing) = Schema{Tuple(map(sym, names)), nothing}()
 
-const SCHEMA_SPECIALIZATION_THRESHOLD = 67000
+const SCHEMA_SPECIALIZATION_THRESHOLD = (2^16) - 1
 
 function Schema(names, types; stored::Bool=false)
     if stored || length(names) > SCHEMA_SPECIALIZATION_THRESHOLD

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -156,7 +156,7 @@ is defined that enables the `fields_to_merge` to be specified as keyword argumen
 """
 rowmerge(row, other) = merge(_row_to_named_tuple(row), _row_to_named_tuple(other))
 rowmerge(row, other, more...) = merge(_row_to_named_tuple(row), rowmerge(other, more...))
-rowmerge(row; fields_to_merge...) = rowmerge(row, fields_to_merge.data)
+rowmerge(row; fields_to_merge...) = rowmerge(row, values(fields_to_merge))
 
 _row_to_named_tuple(row::NamedTuple) = row
 _row_to_named_tuple(row) = NamedTuple(Row(row))


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/900. We have pretty
good tests for wide tables in Tables.jl itself, but we manage to hit
some compiler limit in non-trivial sink functions that have materialized
schemas with over 2^16 columns. This lowers the threshold then to
account for that (ends up being just a few thousand less columns
allowed).