### PR TITLE
Don't lie when calling Tables.Row/Tables.Columns

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -259,7 +259,10 @@ to provide useful default behaviors (allows any `AbstractColumns` to be used lik
 struct Columns{T} <: AbstractColumns
     x::T
 
-    Columns(x::T) where {T} = new{T}(columns(x))
+    function Columns(x)
+        cols = columns(x)
+        return new{typeof(cols)}(cols)
+    end
 end
 
 Columns(x::Columns) = x

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -244,7 +244,7 @@ struct Row{T} <: AbstractRow
     x::T
 end
 
-Row(x::AbstractRow) = x
+Row(x::Row) = x
 
 """
     Tables.Columns(columns)
@@ -260,7 +260,7 @@ struct Columns{T} <: AbstractColumns
     x::T
 end
 
-Columns(x::AbstractColumns) = x
+Columns(x::Columns) = x
 
 # Columns can only wrap something that is a table, so we pass the schema through
 schema(x::Columns) = schema(getx(x))

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -258,6 +258,8 @@ to provide useful default behaviors (allows any `AbstractColumns` to be used lik
 """
 struct Columns{T} <: AbstractColumns
     x::T
+
+    Columns(x::T) where {T} = new{T}(columns(x))
 end
 
 Columns(x::Columns) = x

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -34,7 +34,6 @@ Base.length(m::MatrixTable) = size(getfield(m, :matrix), 1)
 Base.iterate(m::MatrixTable, st=1) = st > length(m) ? nothing : (MatrixRow(st, m), st + 1)
 
 # column interface
-Columns(m::T) where {T <: MatrixTable} = Columns{T}(m)
 columnaccess(::Type{<:MatrixTable}) = true
 columns(m::MatrixTable) = m
 getcolumn(m::MatrixTable, i::Int) = view(getfield(m, :matrix), :, i)


### PR DESCRIPTION
Fixes #254. The problem with returning the input itself for any
`::AbstractColumns` is that it makes it hard to use `Tables.Columns` as
a dispatchable type when desired. If someone passes an object that's
already `::AbstractColumns`, it's also not the end of the world to wrap
it in one more layer where `getcolumn` calls are probably going to get
inlined away anyway.