### PR TITLE
Fix internal use of columnaccess

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -84,7 +84,7 @@ function rows(x::T) where {T}
     isrowtable(x) && return x
     # because this method is being called, we know `x` didn't define it's own Tables.rows
     # first check if it supports column access, and if so, wrap it in a RowIterator
-    if columnaccess(T)
+    if columnaccess(x)
         cols = columns(x)
         return RowIterator(cols, Int(rowcount(cols)))
     # otherwise, if the input is at least iterable, we'll wrap it in an IteratorWrapper


### PR DESCRIPTION
The `istable`/`columnaccess`/`rowaccess` interface functions are always
meant to be called on _instances_, with a default fallback definition
that calls the function on the type of the instance. Implementations are
encouraged to define the interface functions on _types_ where possible,
to ensure the best possible compilation.

Noticed in https://github.com/JuliaData/Tables.jl/issues/257