### PR TITLE
Minor docs clarification for custom types

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -225,20 +225,20 @@ Tables.Columns
 Now that we've seen how one _uses_ the Tables.jl interface, let's walk-through how to implement it; i.e. how can I
 make my custom type valid for Tables.jl consumers?
 
-The interface to becoming a proper table is straightforward:
+For a type `MyTable`, the interface to becoming a proper table is straightforward:
 
-| Required Methods             | Default Definition           | Brief Description                                                                                                               |
-|------------------------------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| `Tables.istable(table)`      |                              | Declare that your table type implements the interface                                                                           |
-|  **One of:**                 |                              |                                                                                                                                 |
-| `Tables.rowaccess(table)`    |                              | Declare that your table type defines a `Tables.rows(table)` method                                                              |
-| `Tables.rows(table)`         |                              | Return an `Tables.AbstractRow`-compatible iterator from your table                                                              |
-| **Or:**                      |                              |                                                                                                                                 |
-| `Tables.columnaccess(table)` |                              | Declare that your table type defines a `Tables.columns(table)` method                                                           |
-| `Tables.columns(table)`      |                              | Return an `Tables.AbstractColumns`-compatible object from your table                                                            |
-| **Optional methods**         |                              |                                                                                                                                 |
-| `Tables.schema(x)`           | `Tables.schema(x) = nothing` | Return a [`Tables.Schema`](@ref) object from your `Tables.AbstractRow` iterator or `Tables.AbstractColumns` object; or `nothing` for unknown schema |
-| `Tables.materializer(table)` | `Tables.columntable`         | Declare a "materializer" sink function for your table type that can construct an instance of your type from any Tables.jl input |
+| Required Methods                       | Default Definition           | Brief Description                                                                                                               |
+|----------------------------------------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `Tables.istable(::Type{MyTable})`      |                              | Declare that your table type implements the interface                                                                           |
+|  **One of:**                           |                              |                                                                                                                                 |
+| `Tables.rowaccess(::Type{MyTable})`    |                              | Declare that your table type defines a `Tables.rows(::MyTable)` method                                                              |
+| `Tables.rows(x::MyTable)`                   |                              | Return an `Tables.AbstractRow`-compatible iterator from your table                                                              |
+| **Or:**                                |                              |                                                                                                                                 |
+| `Tables.columnaccess(::Type{MyTable})` |                              | Declare that your table type defines a `Tables.columns(::MyTable)` method                                                           |
+| `Tables.columns(x::MyTable)`                |                              | Return an `Tables.AbstractColumns`-compatible object from your table                                                            | 
+| **Optional methods**                   |                              |                                                                                                                                 |
+| `Tables.schema(x::MyTable)`                     | `Tables.schema(x) = nothing` | Return a [`Tables.Schema`](@ref) object from your `Tables.AbstractRow` iterator or `Tables.AbstractColumns` object; or `nothing` for unknown schema |
+| `Tables.materializer(::Type{MyTable})` | `Tables.columntable`         | Declare a "materializer" sink function for your table type that can construct an instance of your type from any Tables.jl input |
 
 Based on whether your table type has defined `Tables.rows` or `Tables.columns`, you then ensure that the `Tables.AbstractRow` iterator
 or `Tables.AbstractColumns` object satisfies the respective interface.

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -287,6 +287,10 @@ not all valid tables will return true, since it's possible to satisfy the
 Tables.jl interface at "run-time", e.g. a `Generator` of `NamedTuple`s iterates
 `NamedTuple`s, which satisfies the `AbstractRow` interface, but there's no static way
 of knowing that the generator is a table.
+
+It is recommended that for users implementing `MyType`, they define only
+`istable(::Type{MyType})`. `istable(::MyType)` will then automatically delegate to this
+method.
 """
 function istable end
 
@@ -309,6 +313,10 @@ an object defines `rowaccess` doesn't mean a user should call `Tables.rows` on i
 `Tables.columns` will also work, providing a valid `AbstractColumns` object from the rows.
 Hence, users should call `Tables.rows` or `Tables.columns` depending on what is most
 natural for them to *consume* instead of worrying about what and how the input is oriented.
+
+It is recommended that for users implementing `MyType`, they define only
+`rowaccess(::Type{MyType})`. `rowaccess(::MyType)` will then automatically delegate to this
+method.
 """
 function rowaccess end
 
@@ -328,6 +336,10 @@ mean a user should call `Tables.columns` on it; `Tables.rows` will also work, pr
 valid `AbstractRow` iterator. Hence, users should call `Tables.rows` or `Tables.columns` depending
 on what is most natural for them to *consume* instead of worrying about what and how the
 input is oriented.
+
+It is recommended that for users implementing `MyType`, they define only
+`columnaccess(::Type{MyType})`. `columnaccess(::MyType)` will then automatically delegate to
+this method.
 """
 function columnaccess end
 
@@ -354,6 +366,10 @@ workflows that take table inputs, apply transformations, potentially converting 
 a different form, and end with producing a table of the same type as the original input. The
 default materializer is `Tables.columntable`, which converts any table input into a `NamedTuple`
 of `Vector`s.
+
+It is recommended that for users implementing `MyType`, they define only
+`materializer(::Type{MyType})`. `materializer(::MyType)` will then automatically delegate to
+this method.
 """
 function materializer end
 

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -248,7 +248,7 @@ columnnames(x::CopiedColumns) = columnnames(source(x))
 @inline function columns(x::T) where {T}
     # because this method is being called, we know `x` didn't define it's own Tables.columns method
     # first check if it explicitly supports row access, and if so, build up the desired columns
-    if rowaccess(T)
+    if rowaccess(x)
         r = rows(x)
         return CopiedColumns(buildcolumns(schema(r), r))
     # though not widely supported, if a source supports the TableTraits column interface, use it


### PR DESCRIPTION
Closes https://github.com/JuliaData/Tables.jl/issues/257

This attempts to clarify those places where interface implementers are expected to declare methods taking their type, rather than instances of their type.