### PR TITLE
Fix inconsistency between row and column behavior of MatrixTable

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,14 +239,14 @@ end
     mattbl = Tables.table(mat)
     @test Tables.istable(typeof(mattbl))
     @test Tables.rowaccess(typeof(mattbl))
-    @test Tables.rows(mattbl) === mattbl
     @test Tables.columnaccess(typeof(mattbl))
     @test Tables.columns(mattbl) === mattbl
     @test mattbl.Column1 == [1,2,3]
     @test Tables.getcolumn(mattbl, :Column1) == [1,2,3]
     @test Tables.getcolumn(mattbl, 1) == [1,2,3]
-    matrow = first(mattbl)
-    @test eltype(mattbl) == typeof(matrow)
+    matrowtbl = Tables.rows(mattbl)
+    matrow = first(matrowtbl)
+    @test eltype(matrowtbl) == typeof(matrow)
     @test matrow.Column1 == 1
     @test Tables.getcolumn(matrow, :Column1) == 1
     @test Tables.getcolumn(matrow, 1) == 1


### PR DESCRIPTION
Fixes #261. Because `MatrixTable` subtypes `AbstractColumns`, it
inherits certain behavior like `length`; but when it needs to fulfill
the "rows" interface, it needs `length` to be defined in terms of the #
of rows instead of the # of columns. We fix this inconsistency here by
defining another type that mirrors `MatrixTable` but is used in the rows
case.