### PR TITLE
Avoid assumption that `Tables.getcolumn(x)` always returns an AbstractVector.

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -77,12 +77,12 @@ function matrix(table; transpose::Bool=false)
     if !transpose
         matrix = Matrix{T}(undef, n, p)
         for (i, col) in enumerate(cols)
-            matrix[:, i] = col
+            matrix[:, i] .= col
         end
     else
         matrix = Matrix{T}(undef, p, n)
         for (i, col) in enumerate(cols)
-            matrix[i, :] = col
+            matrix[i, :] .= col
         end
     end
     return matrix

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,6 +206,16 @@ end
     @test Tables.materializer(1) === Tables.columntable
 end
 
+# Table with tuple columns.
+struct MockTable end 
+Tables.istable(::Type{MockTable}) = true
+Tables.columnaccess(::Type{MockTable}) = true
+Tables.columnnames(x::MockTable) = (:a, :b, :c)
+Tables.columns(x::MockTable) = x
+Tables.getcolumn(x::MockTable, ::Symbol) = (1, 2, 3)
+Tables.getcolumn(x::MockTable, ::Int) = (1, 2, 3)
+Tables.schema(x::MockTable) = Tables.Schema((:a, :b, :c), NTuple{3, Int})
+
 @testset "Matrix integration" begin
     rt = [(a=1, b=4.0, c="7"), (a=2, b=5.0, c="8"), (a=3, b=6.0, c="9")]
     nt = (a=[1,2,3], b=[4.0, 5.0, 6.0])
@@ -297,15 +307,7 @@ end
     @test x′ == reshape(x, :, 1) == Tables.matrix(Tables.table(x))
         
     # For the case that `Tables.getcolumn` doesn't return an `AbstractVector`
-    # e.g Tuple, see #263.
-    struct MockTable end #Table with tuple columns.
-    Tables.istable(::Type{MockTable}) = true
-    Tables.columnaccess(::Type{MockTable}) = true
-    Tables.columnnames(x::MockTable) = (:a, :b, :c)
-    Tables.columns(x::MockTable) = x
-    Tables.getcolumn(x::MockTable, ::Symbol) = (1, 2, 3)
-    Tables.getcolumn(x::MockTable, ::Int) = (1, 2, 3)
-    Tables.schema(x::MockTable) = Tables.Schema((:a, :b, :c), NTuple{3, Int})
+    # e.g Tuple, see #263
     @test Tables.matrix(MockTable()) == repeat([1, 2, 3], 1, 3)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -295,6 +295,18 @@ end
     @test keys(Tables.Columns(Tables.table(x, header=["col1"]))) == [:col1]
     x′ = Tables.matrix(tbl)
     @test x′ == reshape(x, :, 1) == Tables.matrix(Tables.table(x))
+        
+    # For the case that `Tables.getcolumn` doesn't return an `AbstractVector`
+    # e.g Tuple, see #263.
+    struct MockTable end #Table with tuple columns.
+    Tables.istable(::Type{MockTable}) = true
+    Tables.columnaccess(::Type{MockTable}) = true
+    Tables.columnnames(x::MockTable) = (:a, :b, :c)
+    Tables.columns(x::MockTable) = x
+    Tables.getcolumn(x::MockTable, ::Symbol) = (1, 2, 3)
+    Tables.getcolumn(x::MockTable, ::Int) = (1, 2, 3)
+    Tables.schema(x::MockTable) = Tables.Schema((:a, :b, :c), NTuple{3, Int})
+    @test Tables.matrix(MockTable()) == repeat([1, 2, 3], 1, 3)
 end
 
 import Base: ==


### PR DESCRIPTION
From the documentation, calling `Tables.getcolumn` on an `AbstractColumns` object should return an `AbstractColumn` object (i.e any object `col` that supports `length(col)` and `col[i]` for any `i = 1:length(col)`). But these objects aren't necessarily instances of `AbstractVectors`. In the case that `Tables.getcolumn` doesn't return an instance of `AbstractVector` the method `Tables.matrix` fails and throws the following error.
```julia
ERROR: ArgumentError: indexed assignment with a single value to many locations is not supported; perhaps use broadcasting `.=` instead?
```

Below is a sample code that leads to the above error.
```julia
struct MockTable end
Tables.istable(::Type{MockTable}) = true
Tables.columnaccess(::Type{MockTable})) = true
Tables.columnnames(x::MockTable) = (:a, :b, :c)
Tables.columns(x::MockTable) = x
Tables.getcolumn(x::MockTable, ::Symbol) = (1, 2, 3)
Tables.getcolumn(x::MockTable, ::Int) = (1, 2, 3)
Tables.schema(x::MockTable) = Tables.Schema((:a, :b, :c), NTuple{3, Int})
Tables.matrix(MockTable())
```
The error is non-existent after this PR.