### PR TITLE
Fix typo in docs excerpt from DataFrames.jl source code

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -160,11 +160,11 @@ getvector(x) = collect(x)
 
 # note that copycols is ignored in this definition (Tables.CopiedColumns implies copies have already been made)
 fromcolumns(x::Tables.CopiedColumns, names; copycols::Bool=true) =
-    DataFrame(AbstractVector[getvector(Tables.getcolumn(x, nm) for nm in names],
+    DataFrame(AbstractVector[getvector(Tables.getcolumn(x, nm)) for nm in names],
               Index(names),
               copycols=false)
-fromcolumns(x; copycols::Bool=true) =
-    DataFrame(AbstractVector[getvector(Tables.getcolumn(x, nm) for nm in names],
+fromcolumns(x, names; copycols::Bool=true) =
+    DataFrame(AbstractVector[getvector(Tables.getcolumn(x, nm)) for nm in names],
               Index(names),
               copycols=copycols)
 


### PR DESCRIPTION
The Tables.jl docs make reference to the DataFrames.jl source code.

The quoted source code has some errors in it (and the quote disagrees with the actual source). This PR fixes those errors.