### PR TITLE
`OrderedDict` for `dictrowtable`

### DIFF
--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -7,7 +7,7 @@ end
     Tables.dictcolumntable(x) => Tables.DictColumnTable
 
 Take any Tables.jl-compatible source `x` and return a `DictColumnTable`, which
-can be thought of as a `Dict` mapping column names as `Symbol`s to `AbstractVector`s.
+can be thought of as a `OrderedDict` mapping column names as `Symbol`s to `AbstractVector`s.
 The order of the input table columns is preserved via the `Tables.schema(::DictColumnTable)`.
 
 For "schema-less" input tables, `dictcolumntable` employs a "column unioning" behavior,
@@ -126,7 +126,7 @@ end
     Tables.dictrowtable(x) => Tables.DictRowTable
 
 Take any Tables.jl-compatible source `x` and return a `DictRowTable`, which
-can be thought of as a `Vector` of `Dict` rows mapping column names as `Symbol`s to values.
+can be thought of as a `Vector` of `OrderedDict` rows mapping column names as `Symbol`s to values.
 The order of the input table columns is preserved via the `Tables.schema(::DictRowTable)`.
 
 For "schema-less" input tables, `dictrowtable` employs a "column unioning" behavior,

--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -141,12 +141,12 @@ the union behavior is needed.
 function dictrowtable(x)
     names = Symbol[]
     seen = Set{Symbol}()
-    types = Dict{Symbol, Type}()
+    types = OrderedDict{Symbol, Type}()
     r = rows(x)
     L = Base.IteratorSize(typeof(r))
-    out = Vector{Dict{Symbol, Any}}(undef, Base.haslength(r) ? length(r) : 0)
+    out = Vector{OrderedDict{Symbol, Any}}(undef, Base.haslength(r) ? length(r) : 0)
     for (i, drow) in enumerate(r)
-        row = Dict{Symbol, Any}(nm => getcolumn(drow, nm) for nm in columnnames(drow))
+        row = OrderedDict{Symbol, Any}(nm => getcolumn(drow, nm) for nm in columnnames(drow))
         add!(row, 0, :_, out, L, i)
         if isempty(names)
             for (k, v) in row

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -345,7 +345,6 @@ end
 Base.eltype(g::GenericColumn{T}) where {T} = T
 Base.length(g::GenericColumn) = length(g.data)
 ==(a::GenericColumn, b::GenericColumn) = a.data == b.data
-Base.size(g::GenericColumn) = (1,)
 Base.getindex(g::GenericColumn, i::Int) = g.data[i]
 
 struct GenericColumnTable

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -345,6 +345,7 @@ end
 Base.eltype(g::GenericColumn{T}) where {T} = T
 Base.length(g::GenericColumn) = length(g.data)
 ==(a::GenericColumn, b::GenericColumn) = a.data == b.data
+Base.size(g::GenericColumn) = (1,)
 Base.getindex(g::GenericColumn, i::Int) = g.data[i]
 
 struct GenericColumnTable


### PR DESCRIPTION
Fixes #274

`OrderedDict` for `dictrowtable`