### PR TITLE
Start an idea of what an "in memory" requirement would look like

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -413,6 +413,15 @@ See also [`rowtable`](@ref) and [`namedtupleiterator`](@ref).
 """
 function rows end
 
+"""
+    Tables.indexablerows(x) => Row indexable
+
+Similar to `Tables.rows`, but instead of only returning an iterator, returns an indexable object.
+This allows random-access to the input table rows, which can be useful in contexts when
+a known subset of the input is needed.
+"""
+function indexablerows end
+
 # Schema implementation
 """
     Tables.Schema(names, types)


### PR DESCRIPTION
This has been requested/discussed a number of times; here's one idea of
what this could look like. Basically the same as `Tables.rows`, but
`Tables.indexablerows` would require an "indexable" object of rows to be
returned instead of just an iterator. Indexable is a little vague; to be
most useful, we should probably require the return object to be
`AbstractVector` since we get lots of fancy indexing/useful behavior
that way. The bare minimum indexing interface is just `getindex`,
`firstindex`, and `lastindex`, but it seems like people would then just
be wanting to do `x[[i, j, k]]` like operations and have to implement
their own. So I'm inclined to make the requirement that you have to
return an `AbstractVector` of rows.