### PR TITLE
Use columntable in datavaluerows for col sources

### DIFF
--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -93,7 +93,15 @@ IteratorInterfaceExtensions.getiterator(x::MyTable) = Tables.datavaluerows(x)
 ```
 """
 function datavaluerows(x)
-    r = Tables.rows(x)
+    x2 = if Tables.columnaccess(x)
+        Tables.columntable(x)
+    elseif Tables.rowaccess(x)
+        x
+    else
+        error("Invalid input table, must either declare to have a Tables.rows or Tables.columns method.")
+    end
+
+    r = Tables.rows(x2)
     s = Tables.schema(r)
     s === nothing && error("Schemaless sources cannot be passed to datavaluerows.")
     return DataValueRowIterator{datavaluenamedtuple(s), typeof(s), typeof(r)}(r)

--- a/src/tofromdatavalues.jl
+++ b/src/tofromdatavalues.jl
@@ -93,15 +93,7 @@ IteratorInterfaceExtensions.getiterator(x::MyTable) = Tables.datavaluerows(x)
 ```
 """
 function datavaluerows(x)
-    x2 = if Tables.columnaccess(x)
-        Tables.columntable(x)
-    elseif Tables.rowaccess(x)
-        x
-    else
-        error("Invalid input table, must either declare to have a Tables.rows or Tables.columns method.")
-    end
-
-    r = Tables.rows(x2)
+    r = Tables.rows(Tables.columnaccess(x) ? Tables.columntable(x) : x)
     s = Tables.schema(r)
     s === nothing && error("Schemaless sources cannot be passed to datavaluerows.")
     return DataValueRowIterator{datavaluenamedtuple(s), typeof(s), typeof(r)}(r)


### PR DESCRIPTION
@quinnj, the idea here would be that https://github.com/JuliaData/DataFrames.jl/blob/b1fdb7621fa38c381dad928317ec1de562d09e71/src/other/tables.jl#L93 could be rewritten as
```julia
IteratorInterfaceExtensions.getiterator(df::AbstractDataFrame) = Tables.datavaluerows(df)
```
But I'm not entirely sure this is right :) I think this PR only makes sense if the idea is that for any table that is primarily column based, one should first create a columntable before one calls the `datavaluerows` function. Is that so? I don't really understand the underlying mechanics there.

The benefit of this PR would be that now the instructions for any Tables.jl source that wants to also enable TableTraits.jl integration would be a bit simpler, i.e. the instructions would be to just always add
```julia
IteratorInterfaceExtensions.getiterator(x::MyType) = Tables.datavaluerows(x)
IteratorInterfaceExtensions.isiterable(::MyType) = true
TableTraits.isiterabletable(::MyType) = true
```
and that would work regardless of whether the source internally stores things as columns or rows.