### PR TITLE
Recommend defining `materializer(::Type{<:MyType})`

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -368,7 +368,7 @@ default materializer is `Tables.columntable`, which converts any table input int
 of `Vector`s.
 
 It is recommended that for users implementing `MyType`, they define only
-`materializer(::Type{MyType})`. `materializer(::MyType)` will then automatically delegate to
+`materializer(::Type{<:MyType})`. `materializer(::MyType)` will then automatically delegate to
 this method.
 """
 function materializer end


### PR DESCRIPTION
For parametric types, defining `materializer(::Type{MyType})` doesn't work,
and this can be hard to catch.