### PR TITLE
Support AbstractDict with String keys as tables

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -144,8 +144,13 @@ getcolumn(x::AbstractDict{Symbol}, nm::Symbol) = x[nm]
 getcolumn(x::AbstractDict{Symbol}, ::Type{T}, i::Int, nm::Symbol) where {T} = x[nm]
 columnnames(x::AbstractDict{Symbol}) = collect(keys(x))
 
+getcolumn(x::AbstractDict{String}, i::Int) = x[String(columnnames(x)[i])]
+getcolumn(x::AbstractDict{String}, nm::Symbol) = x[String(nm)]
+getcolumn(x::AbstractDict{String}, ::Type{T}, i::Int, nm::Symbol) where {T} = x[String(nm)]
+columnnames(x::AbstractDict{String}) = collect(Symbol(k) for k in keys(x))
+
 # AbstractVector of Dicts for Tables.rows
-const DictRows = AbstractVector{T} where {T <: AbstractDict{Symbol}}
+const DictRows = AbstractVector{T} where {T <: Union{AbstractDict{String}, AbstractDict{Symbol}}}
 isrowtable(::Type{<:DictRows}) = true
 # DictRows doesn't naturally lend itself to the `Tables.schema` requirement
 # we can't just look at the first row, because the types might change,
@@ -154,7 +159,7 @@ isrowtable(::Type{<:DictRows}) = true
 schema(x::DictRows) = nothing
 
 # Dict of AbstractVectors for Tables.columns
-const DictColumns = AbstractDict{K, V} where {K <: Symbol, V <: AbstractVector}
+const DictColumns = AbstractDict{K, V} where {K <: Union{Symbol, String}, V <: AbstractVector}
 istable(::Type{<:DictColumns}) = true
 columnaccess(::Type{<:DictColumns}) = true
 columns(x::DictColumns) = x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Tables, TableTraits, DataValues, QueryOperators, IteratorInterfaceExtensions, SparseArrays
+using Test, Tables, OrderedCollections, TableTraits, DataValues, QueryOperators, IteratorInterfaceExtensions, SparseArrays
 
 @testset "utils.jl" begin
 
@@ -541,6 +541,27 @@ end
 
     # a Dict w/ scalar values isn't a table
     @test_throws Exception Tables.columns(d)
+
+    # Dicts with String keys
+    d = OrderedDict("a" => 1, "b" => missing, "c" => "7")
+    n = (a=1, b=missing, c="7")
+    drt = [d, d, d]
+    rt = [n, n, n]
+    dct = OrderedDict("a" => [1, 1, 1], "b" => [missing, missing, missing], "c" => ["7", "7", "7"])
+    ct = (a = [1, 1, 1], b = [missing, missing, missing], c = ["7", "7", "7"])
+    @test Tables.istable(drt)
+    @test Tables.rowaccess(drt)
+    @test Tables.rows(drt) === drt
+    @test Tables.schema(drt) === nothing
+    @test isequal(Tables.rowtable(drt), rt)
+    @test isequal(Tables.columntable(drt), ct)
+
+    @test Tables.istable(dct)
+    @test Tables.columnaccess(dct)
+    @test Tables.columns(dct) === dct
+    @test Tables.schema(dct) == Tables.Schema((:a, :b, :c), Tuple{Int, Missing, String})
+    @test isequal(Tables.rowtable(dct), rt)
+    @test isequal(Tables.columntable(dct), ct)
 end
 
 struct Row <: Tables.AbstractRow


### PR DESCRIPTION
Implements #295. This is fairly simple. I think we didn't do this before because it's a bit weird using plain Dicts because of the lack of schema/column order. But using OrderedDicts makes this a natural use.