### PR TITLE
Fix allocatecolumn

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -103,6 +103,7 @@ end
 
 Custom column types can override with an appropriate "scalar" element type that should dispatch to their column allocator.
 Alternatively, and more generally, custom scalars can overload `DataAPI.defaultarray` to signal the default array type.
+In this case the signaled array type must support a constructor accepting `undef` for initialization.
 """
 function allocatecolumn(T, len)
     a = DataAPI.defaultarray(T, 1)(undef, len)

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -105,7 +105,7 @@ Custom column types can override with an appropriate "scalar" element type that 
 Alternatively, and more generally, custom scalars can overload `DataAPI.defaultarray` to signal the default array type.
 """
 function allocatecolumn(T, len)
-    a = DataAPI.defaultarray(T, 1)(Base.nonmissingtype(T) === T ? undef : missing, len)
+    a = DataAPI.defaultarray(T, 1)(undef, len)
     Missing <: T && fill!(a, missing)
     return a
 end

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -104,7 +104,11 @@ end
 Custom column types can override with an appropriate "scalar" element type that should dispatch to their column allocator.
 Alternatively, and more generally, custom scalars can overload `DataAPI.defaultarray` to signal the default array type.
 """
-allocatecolumn(T, len) = DataAPI.defaultarray(T, 1)(Base.nonmissingtype(T) === T ? undef : missing, len)
+function allocatecolumn(T, len)
+    a = DataAPI.defaultarray(T, 1)(Base.nonmissingtype(T) === T ? undef : missing, len)
+    Missing <: T && fill!(a, missing)
+    return a
+end
 
 @inline function _allocatecolumns(::Schema{names, types}, len) where {names, types}
     if @generated


### PR DESCRIPTION
The reason for the fix is that old code:
* in case eltype is `Any` used `undef` branch (which most of the time works, but it is not guaranteed)
* not all array types support initializer with a value other than `undef` (e.g. this is the case for `CategoricalArray`)

What I propose is a safe approach, but maybe there would be better ideas.

x-ref: massive errors in DataFrames.jl https://github.com/JuliaData/DataFrames.jl/pull/3158

CC @quinnj @nalimilan 
