### PR TITLE
Fix docstring for Tables.rows

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -414,8 +414,8 @@ the columns of the input.
 The [`Tables.Schema`](@ref) of an `AbstractRow` iterator can be queried via `Tables.schema(rows)`,
 which may return `nothing` if the schema is unknown.
 Column names can always be queried by calling `Tables.columnnames(row)` on an individual row,
-and row values can be accessed by calling `Tables.getcolumn(rows, i::Int )` or
-`Tables.getcolumn(rows, nm::Symbol)` with a column index or name, respectively.
+and row values can be accessed by calling `Tables.getcolumn(row, i::Int )` or
+`Tables.getcolumn(row, nm::Symbol)` with a column index or name, respectively.
 
 See also [`rowtable`](@ref) and [`namedtupleiterator`](@ref).
 """


### PR DESCRIPTION
The present docstring for `Tables.rows` suggests that `getcolumn` can be applied to `Tables.rows(X)`, whereas the contract is only that it can be applied to a single row of that object, right?