### PR TITLE
Implement DataAPI.nrow for MatrixTable, DictColumnTable and DictColumnTable

### DIFF
--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -94,6 +94,7 @@ schema(x::DictColumnTable) = getfield(x, :schema)
 columnnames(x::DictColumnTable) = getfield(x, :schema).names
 getcolumn(x::DictColumnTable, i::Int) = getfield(x, :values)[columnnames(x)[i]]
 getcolumn(x::DictColumnTable, nm::Symbol) = getfield(x, :values)[nm]
+DataAPI.nrow(x::DictColumnTable) = length(getfield(x, :values)[columnnames(x)[1]])
 
 # Vector of Dicts as table
 struct DictRowTable
@@ -113,6 +114,7 @@ end
 columnnames(x::DictRow) = getfield(x, :names)
 getcolumn(x::DictRow, i::Int) = get(getfield(x, :row), columnnames(x)[i], missing)
 getcolumn(x::DictRow, nm::Symbol) = get(getfield(x, :row), nm, missing)
+DataAPI.nrow(x::DictRowTable) = length(getfield(x, :values))
 
 Base.IteratorSize(::Type{DictRowTable}) = Base.HasLength()
 Base.length(x::DictRowTable) = length(getfield(x, :values))

--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -95,6 +95,7 @@ columnnames(x::DictColumnTable) = getfield(x, :schema).names
 getcolumn(x::DictColumnTable, i::Int) = getfield(x, :values)[columnnames(x)[i]]
 getcolumn(x::DictColumnTable, nm::Symbol) = getfield(x, :values)[nm]
 DataAPI.nrow(x::DictColumnTable) = length(getfield(x, :values)[columnnames(x)[1]])
+DataAPI.ncol(x::DictColumnTable) = length(getfield(x, :values))
 
 # Vector of Dicts as table
 struct DictRowTable
@@ -115,6 +116,7 @@ columnnames(x::DictRow) = getfield(x, :names)
 getcolumn(x::DictRow, i::Int) = get(getfield(x, :row), columnnames(x)[i], missing)
 getcolumn(x::DictRow, nm::Symbol) = get(getfield(x, :row), nm, missing)
 DataAPI.nrow(x::DictRowTable) = length(getfield(x, :values))
+DataAPI.ncol(x::DictRowTable) = length(getfield(x, :names))
 
 Base.IteratorSize(::Type{DictRowTable}) = Base.HasLength()
 Base.length(x::DictRowTable) = length(getfield(x, :values))

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -20,6 +20,7 @@ end
 const MatrixTables{T} = Union{MatrixTable{T}, MatrixRowTable{T}}
 
 names(m::MatrixTables) = getfield(m, :names)
+DataAPI.nrow(m::T) where {T <: Union{MatrixTable, MatrixRowTable}} = size(getfield(m, :matrix), 1)
 
 # row interface
 istable(::Type{<:MatrixTable}) = true

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -21,6 +21,7 @@ const MatrixTables{T} = Union{MatrixTable{T}, MatrixRowTable{T}}
 
 names(m::MatrixTables) = getfield(m, :names)
 DataAPI.nrow(m::T) where {T <: Union{MatrixTable, MatrixRowTable}} = size(getfield(m, :matrix), 1)
+DataAPI.ncol(m::T) where {T <: Union{MatrixTable, MatrixRowTable}} = size(getfield(m, :matrix), 2)
 
 # row interface
 istable(::Type{<:MatrixTable}) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Tables, OrderedCollections, TableTraits, DataValues, QueryOperators, IteratorInterfaceExtensions, SparseArrays
+using Test, Tables, OrderedCollections, TableTraits, DataValues, QueryOperators, IteratorInterfaceExtensions, SparseArrays, DataAPI
 
 @testset "utils.jl" begin
 
@@ -977,3 +977,15 @@ end
     @test Tables.getcolumn(Dict(SubString("a")=>1, SubString("b")=>2), Int, 1, :a) == 1
 end
                                                                                                                                                
+@testset "DataAPI.nrow for different table types" begin
+    matrix = rand(5, 4)
+    matrixtable = Tables.table(matrix)
+    @test DataAPI.nrow(matrixtable) == size(matrix, 1)
+    dictrowtable = Tables.dictrowtable(matrixtable)
+    @test DataAPI.nrow(dictrowtable) == size(matrix, 1)
+    dictcolumntable = Tables.dictcolumntable(matrixtable)
+    @test DataAPI.nrow(dictcolumntable) == size(matrix, 1)
+end
+    
+    
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -987,5 +987,13 @@ end
     @test DataAPI.nrow(dictcolumntable) == size(matrix, 1)
 end
     
-    
+@testset "DataAPI.ncol for different table types" begin
+    matrix = rand(5, 4)
+    matrixtable = Tables.table(matrix)
+    @test DataAPI.ncol(matrixtable) == size(matrix, 2)
+    dictrowtable = Tables.dictrowtable(matrixtable)
+    @test DataAPI.ncol(dictrowtable) == size(matrix, 2)
+    dictcolumntable = Tables.dictcolumntable(matrixtable)
+    @test DataAPI.ncol(dictcolumntable) == size(matrix, 2)
+end
 


### PR DESCRIPTION
In response to issue #332 