### PR TITLE
remove LinearAlgebra as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "1.11.1"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DataValueInterfaces = "e2d170a0-9d28-54be-80f0-106bbe20a464"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -1,6 +1,6 @@
 module Tables
 
-using LinearAlgebra, DataValueInterfaces, DataAPI, TableTraits, IteratorInterfaceExtensions, OrderedCollections
+using DataValueInterfaces, DataAPI, TableTraits, IteratorInterfaceExtensions, OrderedCollections
 
 export rowtable, columntable
 


### PR DESCRIPTION
seems that `LinearAlgebra` is loaded but not used. this affects downstream uses (as now LinearAlgebra is loaded separately). related: https://github.com/JuliaFolds2/Transducers.jl/issues/35