### PR TITLE
Fix columntable materialization on stored schema

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1040,3 +1040,14 @@ end
     @test DataAPI.nrow(Tables.dictrowtable([(a=1, b=2), (a=3, b=4), (a=5, b=6)])) == 3
     @test DataAPI.ncol(Tables.dictrowtable([(a=1, b=2), (a=3, b=4), (a=5, b=6)])) == 2
 end
+
+@testset "#357" begin
+    dct = Tables.dictcolumntable((a=1:3, b=4.0:6.0, c=["7", "8", "9"]))
+    sch = Tables.schema(dct)
+    sch = Tables.Schema(sch.names, sch.types, stored=true)
+    dct = Tables.DictColumnTable(sch, getfield(dct, :values))
+    nt = Tables.columntable(dct)
+    @test nt.a == [1, 2, 3]
+    @test nt.b == [4.0, 5.0, 6.0]
+    @test nt.c == ["7", "8", "9"]
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaData/Tables.jl/issues/357.

The issue here is for stored schema, the type of the schema is `Schema{nothing, nothing}` which usually indicates tables with many columns. Some tables implementations, however, like ARFFFiles.jl, may choose to explicitly store _all_ schemas, even for very narrow tables. We already have a generated branch which checks for a specialization threshold for the known-schema case, so the fix here is fairly straightforward in just actually checking if the stored schema # of columns is actually too many or not.

In the end, users should be aware that `Tables.columntable` isn't a perfect, 100% kind of table implementation that is always expected to work. It was originally meant as just a test implementation that then turned out to be fairly convenient for REPL use. Users should note that generating a named tuple of columns from stored schema doesn't have a way to be particularly efficient, since it necessarily has to generate the NamedTuple type at runtime.