### PR TITLE
Add link to TableTransforms.jl

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,9 @@ just for a question, or come chat with us on the [#data](https://julialang.slack
 channel with questions, concerns, or clarifications. Also one can find list of packages that supports
 Tables.jl interface in [INTEGRATIONS.md](https://github.com/JuliaData/Tables.jl/blob/master/INTEGRATIONS.md).
 
-Please refer to [TableOperations.jl](https://github.com/JuliaData/TableOperations.jl) for common table operations such as  `select`, `transform`, `filter` and  `map`.
+Please refer to [TableOperations.jl](https://github.com/JuliaData/TableOperations.jl) for common table operations
+such as  `select`, `transform`, `filter` and  `map` and to [TableTransforms.jl](https://github.com/JuliaML/TableTransforms.jl)
+for more sophisticated transformations.
 
 ```@contents
 Depth = 3


### PR DESCRIPTION
This can help end-users of Tables.jl as we implement dozens of transforms that are compatible with the interface.