### PR TITLE
Make AbstractRows print long-ways

### DIFF
--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -201,18 +201,22 @@ function Base.NamedTuple(r::RorC)
 end
 
 function _print_cols(io, inds, nms, max_width, w, h, x)
+    max_ind = maximum(inds)
     for i in inds
         n = nms[i]
         v = x[n]
         s = string(v)
         print(io, rpad(n, max_width + 10, ' '))
         width_renaining = w - 10 - max_width
-        if length(s) < width_renaining
+        if length(s) >= width_renaining
+            s = s[1:(width_renaining)-1] * '⋯'
+        end
+        if i < max_ind
             println(io, s)
         else
-            s_sub = s[1:(width_renaining)-1] * '⋯'
-            println(io, s)
+            print(io, s)
         end
+
     end
 end
 function Base.show(io::IO, x::T) where {T <: AbstractRow}
@@ -232,6 +236,7 @@ function Base.show(io::IO, x::T) where {T <: AbstractRow}
             front_inds = 1:perblock
             back_inds = (N-perblock):N
             _print_cols(io, front_inds, nms, max_width, w, h, x)
+            println()
             println(io, lpad("⋮", max_width + 10, ' '))
             _print_cols(io, back_inds, nms, max_width, w, h, x)
         end

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -230,7 +230,7 @@ function Base.show(io::IO, x::T) where {T <: AbstractRow}
             h = h - 1
             perblock = div(h, 2)
             front_inds = 1:perblock
-            back_inds = N:(-1):(N-perblock)
+            back_inds = (N-perblock):N
             _print_cols(io, front_inds, nms, max_width, w, h, x)
             println(io, lpad("⋮", max_width + 10, ' '))
             _print_cols(io, back_inds, nms, max_width, w, h, x)

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -200,15 +200,46 @@ function Base.NamedTuple(r::RorC)
     return NamedTuple{Tuple(map(Symbol, names))}(Tuple(getcolumn(r, nm) for nm in names))
 end
 
+function _print_cols(io, inds, nms, max_width, w, h, x)
+    for i in inds
+        n = nms[i]
+        v = x[n]
+        s = string(v)
+        print(io, rpad(n, max_width + 10, ' '))
+        width_renaining = w - 10 - max_width
+        if length(s) < width_renaining
+            println(io, s)
+        else
+            s_sub = s[1:(width_renaining)-1] * '⋯'
+            println(io, s)
+        end
+    end
+end
 function Base.show(io::IO, x::T) where {T <: AbstractRow}
     if get(io, :compact, false) || get(io, :limit, false)
-        get(io, :typeinfo, nothing) === nothing && print(io, "$T: ")
-        show(io, NamedTuple(x))
+        (h, w) = displaysize(io)
+        h = h - 5
+        get(io, :typeinfo, nothing) === nothing && print(io, "$(Base.nameof(T)): ")
+        nms = propertynames(x)
+        N = length(nms)
+        max_width = maximum(length ∘ string, nms)
+        print(io, "\n")
+        if N <= 20 || N < h
+            _print_cols(io, 1:N, nms, max_width, w, h, x)
+        else
+            h = h - 1
+            perblock = div(h, 2)
+            front_inds = 1:perblock
+            back_inds = N:(-1):(N-perblock)
+            _print_cols(io, front_inds, nms, max_width, w, h, x)
+            println(io, lpad("⋮", max_width + 10, ' '))
+            _print_cols(io, back_inds, nms, max_width, w, h, x)
+        end
     else
         # Assume we are called from within a container show method when typeinfo is set.
         get(io, :typeinfo, nothing) !== nothing && println(io)
 
-        println(io, "$T:")
+        println(io, "$(Base.nameof(T)):")
         names = collect(columnnames(x))
         values = [getcolumn(x, nm) for nm in names]
         Base.print_matrix(io, hcat(names, values))


### PR DESCRIPTION
1. I got rid of printing the type parameters
2. I print each element in a row vertically
3. I do some corrections similar to dataframes about the height and width of the screen. 

An example here [x-ref](https://github.com/JuliaData/DataFrames.jl/issues/2616#issuecomment-3216959296) in DataFrames.jl

```julia
(Tables) julia> using Tables

(Tables) julia> nt = (;(Symbol("x$i") => rand() for i in 1:50)...,);

(Tables) julia> t = Row(nt)
Row: 
x1           0.726270389343219
x2           0.2826873308517256
x3           0.30245552857274705
x4           0.2564103387347969
x5           0.114357002151807
x6           0.7268839730501291
            ⋮
x50          0.43397092645961866
x49          0.40254808328675196
x48          0.934923884837159
x47          0.1640042997187814
x46          0.7799762481712108
x45          0.44932545509234945
x44          0.09937457554982676
```