### PR TITLE
Add Tables.Scan and generic scan execution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
@@ -11,7 +11,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 
 [compat]
-DataAPI = "1"
+DataAPI = "1.1"
 DataValueInterfaces = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"
 OrderedCollections = "1, 2"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ DataValueInterfaces = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"
 OrderedCollections = "1"
 TableTraits = "0.4.1, 1"
-julia = "1"
+julia = "1.9"
 
 [extras]
 DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "Using the Interface" => "using-the-interface.md",
+        "Scan Requests" => "scan.md",
         "Implementing the Interface" => "implementing-the-interface.md",
         "API Reference" => "api.md",
     ],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,9 @@ just for a question, or come chat with us on the [#data](https://julialang.slack
 channel with questions, concerns, or clarifications. Also one can find list of packages that supports
 Tables.jl interface in [INTEGRATIONS.md](https://github.com/JuliaData/Tables.jl/blob/master/INTEGRATIONS.md).
 
-Please refer to [TableOperations.jl](https://github.com/JuliaData/TableOperations.jl) for common table operations
+For declarative projection, filtering, and row bounds that sources can push
+down, see [Scan Requests](scan.md) (`Tables.Scan`). Please refer to
+[TableOperations.jl](https://github.com/JuliaData/TableOperations.jl) for common table operations
 such as  `select`, `transform`, `filter` and  `map` and to [TableTransforms.jl](https://github.com/JuliaML/TableTransforms.jl)
 for more sophisticated transformations.
 
@@ -21,6 +23,7 @@ Depth = 3
 Pages = [
     "index.md",
     "using-the-interface.md",
+    "scan.md",
     "implementing-the-interface.md",
     "api.md",
 ]

--- a/docs/src/scan.md
+++ b/docs/src/scan.md
@@ -55,7 +55,7 @@ Tables.Scan(select = (
     :id,
     r"^metric_",
     :price => Float64,
-    :timestamp => DateTime => :created_at,
+    :qty => Int => :quantity,
 ))
 ```
 
@@ -122,17 +122,29 @@ bound = Tables.resolve(request, source_names)
 mask = Tables.filtermask(bound, predicate_columns)
 ```
 
-If a source consumes an axis, it removes that axis from the residual. For
-example, a source that performs projection but leaves filtering and row bounds
-for the generic executor can use:
+If a source consumes an axis, it removes that axis from the residual. The
+axes compose in a fixed order — filter, then row bounds, then projection —
+so an axis can only be removed together with every axis that executes before
+it. A source that evaluated the filter itself (for example with
+`Tables.filtermask`) hands the rest to the generic executor:
 
 ```julia
-residual = Tables.Scan(request; select=Tables.All())
-result = Tables.scan(materialized_columns, residual)
+residual = Tables.Scan(request; filter=nothing)
+result = Tables.scan(filtered_columns, residual)
 ```
 
-`Tables.All()` is the projection identity, so the residual does not repeat
-projection work. Only remove work that the source performed exactly.
+A source that also applied `limit`/`offset` to the qualifying rows strips
+those too (`Tables.Scan(request; filter=nothing, limit=nothing, offset=0)`,
+leaving only projection). Two constraints follow from the ordering:
+
+- `limit`/`offset` count qualifying rows, after the filter. A source that
+  cannot consume the filter must leave the row bounds in the residual as
+  well.
+- Projection may be stripped (`select=Tables.All()`, the projection identity)
+  only when no residual filter references a column the projection dropped or
+  renamed — the residual filter still uses source column names.
+
+Only remove work that the source performed exactly.
 
 A statistics check that only prunes impossible partitions does not consume the
 filter.

--- a/docs/src/scan.md
+++ b/docs/src/scan.md
@@ -1,0 +1,157 @@
+# Scan Requests
+
+`Tables.Scan` is a logical request for projection, filtering, row bounds, and
+output conversion. It does not require a physical full-table scan. A source can
+use an index, statistics, partition pruning, or any other exact optimization.
+
+The API has two roles:
+
+- Consumers construct a [`Tables.Scan`](@ref) and pass it to a source or to
+  [`Tables.scan`](@ref).
+- Source implementations inspect, resolve, and consume supported parts of the
+  request while they read data.
+
+## Consumer API
+
+```@example scan
+using Tables
+
+table = (
+    id = [1, 2, 3, 4],
+    status = ["trial", "active", "active", "closed"],
+    price = [5, 20, 12, 30],
+)
+
+request = Tables.Scan(
+    select = (:id, :price => Float64 => :amount),
+    filter = Tables.colcmp(==, Tables.col(:status), "active") &
+             (Tables.col(:price) >= 10),
+    limit = 10,
+)
+
+Tables.scan(table, request)
+```
+
+The operation order is fixed:
+
+1. Resolve references against source column names.
+2. Evaluate the filter.
+3. Apply `offset`, then `limit`, to qualifying rows.
+4. Select, rename, and convert output columns.
+
+Filters always use source names. A rename does not change the name visible to
+the filter.
+
+### Selection
+
+`select=nothing` keeps every column and also means that the projection axis was
+not requested. This distinction matters when a source builds a residual
+request. An explicit `Tables.All()` is a selection item that expands to every
+source column.
+
+A selection accepts names, indices, regular expressions, `Tables.All()`, and
+`Tables.Not(...)`. Pair forms add a type override or output name:
+
+```julia
+Tables.Scan(select = (
+    :id,
+    r"^metric_",
+    :price => Float64,
+    :timestamp => DateTime => :created_at,
+))
+```
+
+Selection order defines output order. Duplicate output names are an error.
+
+### Filter expressions
+
+`Tables.col(ref)` creates a column reference. The supported predicates are:
+
+- `Tables.colcmp(op, column, value)` for `==`, `!=`, `<`, `<=`, `>`, and `>=`.
+- Ordered shorthand such as `Tables.col(:price) >= 10`.
+- `Tables.colin(column, values)` for membership.
+- `Tables.isnull(column)` and its negation for `missing` checks.
+- `startswith`, `endswith`, and `contains` for strings.
+- `&`, `|`, and `!` for Boolean composition.
+
+Expression nodes contain plain data. They do not store callbacks. This makes a
+request inspectable and suitable for serialization, pushdown, and static
+compilation.
+
+### Missing values
+
+Filter evaluation uses SQL-like three-valued logic:
+
+- Comparisons, membership, and string predicates lift a missing column value to
+  `missing`.
+- `Tables.isnull(column)` returns `true` for `missing` and `false` otherwise.
+- `&`, `|`, and `!` propagate `missing` with three-valued Boolean rules.
+- The top-level filter keeps a row only when its result is exactly `true`.
+
+These lifting rules are deliberate. Julia functions other than comparison
+operators do not generally lift `missing` on their own.
+
+The name `Tables.isnull` also avoids defining `Base.ismissing(::Tables.Col)`.
+Such a method would specialize a broad Base fallback and can invalidate
+unrelated compiled code when Tables loads.
+
+### Unmatched references
+
+The default `validate=true` rejects any selection or filter reference that does
+not match the source schema. With `validate=false`, an unmatched selection is
+dropped and an unmatched filter column behaves as an all-missing column. This
+mode supports schema evolution when fields can be absent.
+
+## Source Implementations
+
+A source does not need to support every operation. It can consume the parts it
+can implement exactly and pass the rest to [`Tables.scan`](@ref). It can also
+reject a request that it cannot safely execute.
+
+[`Tables.resolve`](@ref) resolves a request against source names. Its
+`BoundScan` result contains:
+
+- `columns`: selected source indices, output names, and type overrides.
+- `filter`: a filter with positional references normalized to source names.
+- `filtercols`: source indices required by the filter.
+- `limit`, `offset`, and `validate`: the remaining row and validation settings.
+
+The normalized filter can be evaluated over a table containing only the
+`filtercols` columns:
+
+```julia
+bound = Tables.resolve(request, source_names)
+mask = Tables.filtermask(bound, predicate_columns)
+```
+
+If a source consumes an axis, it removes that axis from the residual. For
+example, a source that performs projection but leaves filtering and row bounds
+for the generic executor can use:
+
+```julia
+residual = Tables.Scan(request; select=nothing)
+result = Tables.scan(materialized_columns, residual)
+```
+
+Only remove work that was performed exactly. A statistics check that only
+prunes impossible partitions does not consume the filter.
+
+`Tables.OpNode(name, args)` is the extension point for source-specific,
+plain-data operations. A source can recognize and consume a named operation
+before it calls `Tables.resolve`. Resolution and the generic executor reject an
+unconsumed `OpNode`.
+
+Zero-column results retain their row count. Sources should preserve the same
+property when they return a fully pushed result.
+
+```@docs; canonical = false
+Tables.Scan
+Tables.scan
+Tables.col
+Tables.colcmp
+Tables.colin
+Tables.isnull
+Tables.resolve
+Tables.filtermask
+Tables.describe
+```

--- a/docs/src/scan.md
+++ b/docs/src/scan.md
@@ -44,10 +44,8 @@ the filter.
 
 ### Selection
 
-`select=nothing` keeps every column and also means that the projection axis was
-not requested. This distinction matters when a source builds a residual
-request. An explicit `Tables.All()` is a selection item that expands to every
-source column.
+`select=Tables.All()` is the default and keeps every column. `select=()` selects
+zero columns while preserving the result's row count.
 
 A selection accepts names, indices, regular expressions, `Tables.All()`, and
 `Tables.Not(...)`. Pair forms add a type override or output name:
@@ -129,12 +127,15 @@ example, a source that performs projection but leaves filtering and row bounds
 for the generic executor can use:
 
 ```julia
-residual = Tables.Scan(request; select=nothing)
+residual = Tables.Scan(request; select=Tables.All())
 result = Tables.scan(materialized_columns, residual)
 ```
 
-Only remove work that was performed exactly. A statistics check that only
-prunes impossible partitions does not consume the filter.
+`Tables.All()` is the projection identity, so the residual does not repeat
+projection work. Only remove work that the source performed exactly.
+
+A statistics check that only prunes impossible partitions does not consume the
+filter.
 
 `Tables.OpNode(name, args)` is the extension point for source-specific,
 plain-data operations. A source can recognize and consume a named operation

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -706,6 +706,8 @@ include("matrix.jl")
 # dict tables
 include("dicts.jl")
 
+include("scan.jl")
+
 """
     Tables.columnindex(table, name::Symbol)
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -65,7 +65,15 @@ function _selectitem(x::Not)
         throw(ArgumentError("Not references must be Symbol/String/Int/Regex values"))
     return SelectItem(x, nothing, nothing)
 end
-_selectitem(x::Union{Symbol, String, Int, Regex, Not, All}) = SelectItem(x, nothing, nothing)
+function _selectitem(x::All)
+    # DataAPI.All(cols...) with arguments is deprecated DataFrames syntax;
+    # silently selecting every column would be a data-loss trap
+    isempty(x.cols) ||
+        throw(ArgumentError("Tables.All() takes no arguments in a scan selection; " *
+                            "list the columns directly instead of All(cols...)"))
+    return SelectItem(x, nothing, nothing)
+end
+_selectitem(x::Union{Symbol, String, Int, Regex, Not}) = SelectItem(x, nothing, nothing)
 _selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, Symbol}) = SelectItem(p.first, nothing, p.second)
 _selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, String}) = SelectItem(p.first, nothing, Symbol(p.second))
 _selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, <:Type}) = SelectItem(p.first, p.second, nothing)
@@ -581,7 +589,11 @@ filtermask(s::BoundScan, table) = s.filter === nothing ?
 
 _converted(::Nothing, c::AbstractVector) = c
 function _converted(::Type{T}, c::AbstractVector) where {T}
-    eltype(c) <: Union{T, Missing} && return c
+    # eltype Union{} (necessarily empty) is vacuously <: everything, but the
+    # requested output schema still owes the override type
+    if eltype(c) !== Union{} && eltype(c) <: Union{T, Missing}
+        return c
+    end
     anymissing = any(ismissing, c)
     E = anymissing ? Union{T, Missing} : T
     out = allocatecolumn(E, length(c))

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -9,8 +9,9 @@
 # scan=Tables.Scan(...))`, `Arrow.Table(path; scan=...)` — and apply what they
 # can WHILE materializing (skipping columns never parsed, rows never decoded).
 # What a source cannot push down it either rejects with an ArgumentError, or
-# hands to `Tables.scan` as a residual (`Tables.Scan(scan; select=All())`
-# strips the axes it already handled). Sources are free to support only a
+# hands to `Tables.scan` as a residual (e.g. `Tables.Scan(scan; filter=nothing)`
+# after evaluating the filter itself; axes strip in execution order — filter,
+# then row bounds, then projection). Sources are free to support only a
 # subset — the value is the shared vocabulary and the pushdown, not a
 # capability-negotiation protocol.
 #
@@ -283,10 +284,10 @@ qualify, and how many. Plain data all the way down — see `Tables.scan` for
 the generic executor and the module comment for how sources push it down.
 
   * `select`: a column reference or tuple/vector of select items
-    (`ref`, `ref => name`, `ref => Type`, `ref => Type => name`;
-    refs are `Symbol`/`String`/`Int`/`Regex`/`Tables.Not`/`Tables.All`).
-    `Tables.All()` keeps every column; `()` selects zero columns. Selection
-    order = output order.
+    (`ref`, `ref => name`, `ref => Type`, `ref => Type => name`; refs in the
+    pair forms are `Symbol`/`String`/`Int`/`Regex`, while bare `Tables.Not`
+    and `Tables.All()` items stand alone). `Tables.All()` keeps every column;
+    `()` selects zero columns. Selection order = output order.
   * `filter`: an expression built from `Tables.col`; a row is kept iff the
     predicate evaluates to exactly `true` (`missing` excludes, SQL-style).
     Filters see source column names, before renames.
@@ -333,9 +334,16 @@ end
                 limit=scan.limit, offset=scan.offset, validate=scan.validate)
 
 Copy a scan with some axes replaced — how a source builds the RESIDUAL it
-hands to `Tables.scan` after pushing the rest down: a reader that handled
-projection, types and limits itself but cannot filter does
-`Tables.scan(table, Tables.Scan(scan; select=All(), limit=nothing, offset=0))`.
+hands to `Tables.scan` after pushing the rest down. The axes compose in a
+fixed order — filter, then row bounds, then projection — so a source may only
+strip an axis it performed exactly, together with every axis that comes
+before it: a reader that evaluated the filter itself hands over
+`Tables.Scan(scan; filter=nothing)`; one that also applied the row bounds
+hands over `Tables.Scan(scan; filter=nothing, limit=nothing, offset=0)`.
+Projection (`select=All()`) can only be stripped in addition when no residual
+filter references a column the projection dropped or renamed. A reader that
+cannot consume the filter must leave `limit`/`offset` in the residual too —
+they count qualifying rows, not raw rows.
 """
 function Scan(s::Scan; select=s.select, filter=s.filter,
               limit::Union{Nothing, Integer}=s.limit,

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -5,7 +5,7 @@
 #     table, residual = Tables.apply(source, scan)   # source consumes what it can
 #     table′          = Tables.finish(table, residual)  # generic layer does the rest
 #
-# with `Tables.read(source, scan)` composing the two. The default `apply`
+# with `Tables.scan(source, scan)` composing the two. The default `apply`
 # pushes nothing (everything lands in the residual), so every existing
 # Tables.jl source already works — sources override `apply` to earn
 # performance, never correctness.
@@ -203,7 +203,7 @@ _checkpredicate(x) =
 
 A scan request: what to keep, what to call it, how to type it, which rows
 qualify, and how many. Plain data all the way down — see `Tables.apply`,
-`Tables.finish`, and `Tables.read` for the protocol.
+`Tables.finish`, and `Tables.scan` for the protocol.
 
   * `select`: a column reference or tuple/vector of select items
     (`ref`, `ref => name`, `ref => Type`, `ref => Type => name`;
@@ -519,12 +519,15 @@ nothing, so every Tables.jl source works unmodified. Contract:
 apply(source, scan::Scan) = (source, scan)
 
 """
-    Tables.read(source, scan::Scan)
+    Tables.scan(source, scan::Scan)
 
 `Tables.finish(Tables.apply(source, scan)...)` — the one-call entry point.
+Sources that push scans down (a CSV reader, a database) implement
+`Tables.apply`; `Tables.scan` composes it with the generic `finish` so
+callers never see the residual.
 """
-function read(source, scan::Scan)
-    t, residual = apply(source, scan)
+function scan(source, s::Scan)
+    t, residual = apply(source, s)
     return finish(t, residual)
 end
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -18,8 +18,8 @@
 #     prunes by a predicate but cannot guarantee exactness keeps the filter in
 #     the residual).
 #   * Missing follows SQL WHERE: a predicate evaluating to `missing` excludes
-#     the row. `isnull`/`!isnull` are first-class nodes; `==` never matches
-#     missing.
+#     the row. `ismissing`/`!ismissing` are first-class nodes; `coleq` never
+#     matches missing.
 #   * Filters reference SOURCE column names (pre-rename); the pipeline order
 #     is fixed: bind → filter → offset/limit → project/rename/type.
 #   * Selection order defines output order.
@@ -62,6 +62,12 @@ struct SelectItem
     rename::Union{Nothing, Symbol}
 end
 
+function _selectitem(x::Not)
+    refs = x.ref isa Union{Tuple, AbstractVector} ? x.ref : (x.ref,)
+    all(r -> r isa ColRef, refs) ||
+        throw(ArgumentError("Not references must be Symbol/String/Int/Regex values"))
+    return SelectItem(x, nothing, nothing)
+end
 _selectitem(x::Union{Symbol, String, Int, Regex, Not, All}) = SelectItem(x, nothing, nothing)
 _selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, Symbol}) = SelectItem(p.first, nothing, p.second)
 _selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, String}) = SelectItem(p.first, nothing, Symbol(p.second))
@@ -83,7 +89,7 @@ abstract type ScanExpr end
     Tables.col(ref)
 
 A column reference inside a `Scan` filter: `col(:price) > 100`. Comparisons
-against literals, `in_`, `isnull`, `startswith`/`endswith`/`contains`, and
+against literals, `in_`, `ismissing`, `startswith`/`endswith`/`contains`, and
 `&`/`|`/`!` build plain expression values.
 """
 struct Col <: ScanExpr
@@ -98,7 +104,32 @@ struct Cmp{T} <: ScanExpr
     op::UInt8
     lhs::Col
     rhs::T
+    function Cmp(op::Integer, lhs::Col, rhs::T) where {T}
+        OP_EQ <= op <= OP_GE ||
+            throw(ArgumentError("unknown comparison operator code $op"))
+        return new{T}(UInt8(op), lhs, rhs)
+    end
 end
+
+"""
+    Tables.coleq(col, value)
+    Tables.colne(col, value)
+    Tables.collt(col, value)
+    Tables.colle(col, value)
+    Tables.colgt(col, value)
+    Tables.colge(col, value)
+
+Build a comparison predicate for a column and a literal value. These named
+constructors accept any literal type. `<`, `<=`, `>`, and `>=` provide shorthand
+for numeric, string, and character values. Equality uses `coleq` and `colne` so
+`Base.isequal` keeps its Boolean contract.
+"""
+coleq(c::Col, value) = Cmp(OP_EQ, c, value)
+colne(c::Col, value) = Cmp(OP_NE, c, value)
+collt(c::Col, value) = Cmp(OP_LT, c, value)
+colle(c::Col, value) = Cmp(OP_LE, c, value)
+colgt(c::Col, value) = Cmp(OP_GT, c, value)
+colge(c::Col, value) = Cmp(OP_GE, c, value)
 
 struct In{T} <: ScanExpr
     lhs::Col
@@ -112,18 +143,21 @@ Membership predicate: `in_(col(:status), ("active", "trial"))`.
 """
 in_(c::Col, values) = In(c, values)
 
-struct IsNull <: ScanExpr
+struct IsMissing <: ScanExpr
     lhs::Col
     negated::Bool
 end
 
 """
-    Tables.isnull(col)
+    Tables.ismissing(col)
 
-Missing-ness predicate. Use this — never `col(:x) == missing`, which follows
-SQL semantics and matches no row.
+Missing-ness predicate. Use this rather than `coleq(col(:x), missing)`, which
+follows SQL semantics and matches no row.
 """
-isnull(c::Col) = IsNull(c, false)
+# Keep this function Tables-local. Base.ismissing has an Any fallback, so a Col
+# method there invalidates unrelated precompiled code.
+function ismissing end
+ismissing(c::Col) = IsMissing(c, false)
 
 const STR_STARTSWITH, STR_ENDSWITH, STR_CONTAINS = 0x01, 0x02, 0x03
 
@@ -131,6 +165,11 @@ struct StrPred <: ScanExpr
     kind::UInt8
     lhs::Col
     s::String
+    function StrPred(kind::Integer, lhs::Col, s::AbstractString)
+        STR_STARTSWITH <= kind <= STR_CONTAINS ||
+            throw(ArgumentError("unknown string predicate code $kind"))
+        return new(UInt8(kind), lhs, String(s))
+    end
 end
 
 struct AndExpr <: ScanExpr
@@ -159,24 +198,26 @@ end
 
 _colcolerr() = throw(ArgumentError("column-to-column comparisons are not supported; " *
                                    "compare a column against a literal value"))
-for (f, op) in ((:(==), :OP_EQ), (:<, :OP_LT), (:<=, :OP_LE), (:>, :OP_GT), (:>=, :OP_GE))
-    revop = f === :(==) ? :OP_EQ : f === :< ? :OP_GT : f === :<= ? :OP_GE :
-            f === :> ? :OP_LT : :OP_LE
+for f in (:coleq, :colne, :collt, :colle, :colgt, :colge)
+    @eval $f(::Col, ::Col) = _colcolerr()
+end
+for T in (Number, AbstractString, AbstractChar)
     @eval begin
-        Base.$f(c::Col, v) = Cmp($op, c, v)
-        Base.$f(v, c::Col) = Cmp($revop, c, v)
-        Base.$f(::Col, ::Col) = _colcolerr()
+        Base.:<(c::Col, v::$T) = collt(c, v)
+        Base.:<(v::$T, c::Col) = colgt(c, v)
+        Base.:<=(c::Col, v::$T) = colle(c, v)
+        Base.:<=(v::$T, c::Col) = colge(c, v)
     end
 end
-Base.:(!=)(c::Col, v) = NotExpr(Cmp(OP_EQ, c, v))
-Base.:(!=)(v, c::Col) = NotExpr(Cmp(OP_EQ, c, v))
-Base.:(!=)(::Col, ::Col) = _colcolerr()
-Base.isequal(c::Col, v) = Cmp(OP_EQ, c, v)   # convenience alias; == semantics
+Base.:(==)(a::Col, b::Col) = a.ref == b.ref
+Base.isequal(a::Col, b::Col) = isequal(a.ref, b.ref)
+Base.hash(c::Col, h::UInt) = hash(c.ref, hash(:TablesCol, h))
+Base.:<(::Col, ::Col) = _colcolerr()
+Base.:<=(::Col, ::Col) = _colcolerr()
 
 Base.startswith(c::Col, s::AbstractString) = StrPred(STR_STARTSWITH, c, String(s))
 Base.endswith(c::Col, s::AbstractString) = StrPred(STR_ENDSWITH, c, String(s))
 Base.contains(c::Col, s::AbstractString) = StrPred(STR_CONTAINS, c, String(s))
-Base.in(c::Col, values) = In(c, values)
 
 _ands(e::AndExpr) = e.args
 _ands(e::ScanExpr) = ScanExpr[e]
@@ -186,7 +227,7 @@ Base.:&(a::ScanExpr, b::ScanExpr) = AndExpr(vcat(_ands(a), _ands(b)))
 Base.:|(a::ScanExpr, b::ScanExpr) = OrExpr(vcat(_ors(a), _ors(b)))
 Base.:!(e::ScanExpr) = NotExpr(e)
 Base.:!(e::NotExpr) = e.arg
-Base.:!(e::IsNull) = IsNull(e.lhs, !e.negated)
+Base.:!(e::IsMissing) = IsMissing(e.lhs, !e.negated)
 
 # a bare Col is not a predicate; catch the likely mistake early
 _checkpredicate(::Nothing) = nothing
@@ -216,7 +257,7 @@ qualify, and how many. Plain data all the way down — see `Tables.apply`,
   * `validate`: error on select/filter references that match no column.
     `false` is the schema-evolution knob: unmatched SELECT references are
     silently dropped, and an unmatched FILTER reference evaluates as an
-    all-missing column (`isnull(col(:gone))` keeps every row; comparisons
+    all-missing column (`ismissing(col(:gone))` keeps every row; comparisons
     against it exclude, SQL-style).
 """
 struct Scan
@@ -274,7 +315,7 @@ end
 
 A `Scan` resolved against a concrete schema: output columns in order, the
 (validated) filter with the source column indices it references, and the
-row bounds. Sources consume this, not the raw `Scan`.
+row bounds. Sources can use this after binding a raw `Scan`.
 """
 struct BoundScan
     columns::Vector{BoundColumn}
@@ -321,7 +362,7 @@ _notrefs(x::Union{Tuple, AbstractVector}) = collect(Any, x)
 _notrefs(x) = Any[x]
 
 function _filterrefs!(refs::Vector{Int}, e::ScanExpr, names, validate::Bool)
-    if e isa Union{Cmp, In, IsNull, StrPred}
+    if e isa Union{Cmp, In, IsMissing, StrPred}
         i = _findcol(names, e.lhs.ref)
         i === nothing && validate &&
             throw(ArgumentError("filter references unknown column $(_refstr(e.lhs.ref))"))
@@ -394,7 +435,7 @@ _getcol(cols, ref::Int) = getcolumn(cols, ref)
 # Resolve a filter leaf's column. Under `strict` an unknown reference is an
 # error; otherwise it resolves to `nothing` and the leaf evaluates as an
 # ALL-MISSING column — the schema-evolution semantics: a column this table
-# does not have reads as null everywhere (`isnull` keeps every row, every
+# does not have reads as missing everywhere (`ismissing` keeps every row, every
 # comparison excludes, and three-valued `&`/`|` compose from there).
 function _resolvecol(cols, ref, strict::Bool)
     i = _findcol(columnnames(cols), ref)
@@ -415,27 +456,34 @@ function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
         a === nothing && return fill(missing, rowcount(cols))
         v = Ref(e.rhs)
         return e.op == OP_EQ ? (a .== v) :
+               e.op == OP_NE ? (a .!= v) :
                e.op == OP_LT ? (a .< v) :
                e.op == OP_LE ? (a .<= v) :
-               e.op == OP_GT ? (a .> v) : (a .>= v)
+               e.op == OP_GT ? (a .> v) :
+               e.op == OP_GE ? (a .>= v) :
+               throw(ArgumentError("unknown comparison operator code $(e.op)"))
     elseif e isa In
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
         return in.(a, Ref(e.values))
-    elseif e isa IsNull
+    elseif e isa IsMissing
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing &&
             return e.negated ? falses(rowcount(cols)) : trues(rowcount(cols))
-        return e.negated ? .!ismissing.(a) : ismissing.(a)
+        return e.negated ? .!Base.ismissing.(a) : Base.ismissing.(a)
     elseif e isa StrPred
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
         f = e.kind == STR_STARTSWITH ? startswith :
-            e.kind == STR_ENDSWITH ? endswith : contains
-        return map(x -> ismissing(x) ? missing : f(x, e.s), a)
+            e.kind == STR_ENDSWITH ? endswith :
+            e.kind == STR_CONTAINS ? contains :
+            throw(ArgumentError("unknown string predicate code $(e.kind)"))
+        return map(x -> Base.ismissing(x) ? missing : f(x, e.s), a)
     elseif e isa AndExpr
+        isempty(e.args) && return trues(rowcount(cols))
         return mapreduce(a -> _evalexpr(a, cols, strict), (x, y) -> x .& y, e.args)
     elseif e isa OrExpr
+        isempty(e.args) && return falses(rowcount(cols))
         return mapreduce(a -> _evalexpr(a, cols, strict), (x, y) -> x .| y, e.args)
     elseif e isa NotExpr
         return .!_evalexpr(e.arg, cols, strict)
@@ -448,7 +496,7 @@ function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
 end
 
 """
-    Tables.filtermask(scan_or_expr, table) -> Vector{Bool}
+    Tables.filtermask(scan_or_expr, table) -> AbstractVector{Bool}
 
 Evaluate a scan's filter over a table's columns: `mask[i]` is `true` iff row
 `i` qualifies (a `missing` predicate result excludes the row). Sources use
@@ -465,10 +513,13 @@ filtermask(s::Scan, table) = s.filter === nothing ?
 _converted(::Nothing, c::AbstractVector) = c
 function _converted(::Type{T}, c::AbstractVector) where {T}
     eltype(c) <: Union{T, Missing} && return c
-    anymissing = any(ismissing, c)
+    anymissing = any(Base.ismissing, c)
     E = anymissing ? Union{T, Missing} : T
-    return E[ismissing(x) ? missing : convert(T, x) for x in c]
+    return E[Base.ismissing(x) ? missing : convert(T, x) for x in c]
 end
+
+_takecolumn(c::AbstractVector, idx) = c[idx]
+_takecolumn(c, idx) = [c[i] for i in idx]
 
 """
     Tables.finish(table, residual::Scan) -> table′
@@ -489,11 +540,12 @@ function finish(table, scan::Scan)
     else
         idx = collect(1:rowcount(cols))
     end
-    lo = scan.offset + 1
-    hi = scan.limit === nothing ? length(idx) : min(length(idx), scan.offset + scan.limit)
-    idx = idx[lo:max(hi, lo - 1)]
+    skipped = min(scan.offset, length(idx))
+    available = length(idx) - skipped
+    taken = scan.limit === nothing ? available : min(scan.limit, available)
+    idx = idx[(skipped + 1):(skipped + taken)]
     outnames = Tuple(c.name for c in b.columns)
-    outcols = Tuple(_converted(c.type, getcolumn(cols, c.index)[idx]) for c in b.columns)
+    outcols = Tuple(_converted(c.type, _takecolumn(getcolumn(cols, c.index), idx)) for c in b.columns)
     return NamedTuple{outnames}(outcols)
 end
 
@@ -536,12 +588,14 @@ end
 function _exprstr(e::ScanExpr)
     e isa Cmp && return "col($(repr(e.lhs.ref))) $(_OPNAMES[e.op]) $(repr(e.rhs))"
     e isa In && return "in_(col($(repr(e.lhs.ref))), $(repr(e.values)))"
-    e isa IsNull && return (e.negated ? "!isnull(" : "isnull(") * "col($(repr(e.lhs.ref))))"
+    e isa IsMissing && return (e.negated ? "!ismissing(" : "ismissing(") * "col($(repr(e.lhs.ref))))"
     e isa StrPred && return (e.kind == STR_STARTSWITH ? "startswith" :
                              e.kind == STR_ENDSWITH ? "endswith" : "contains") *
                             "(col($(repr(e.lhs.ref))), $(repr(e.s)))"
-    e isa AndExpr && return join(("(" * _exprstr(a) * ")" for a in e.args), " & ")
-    e isa OrExpr && return join(("(" * _exprstr(a) * ")" for a in e.args), " | ")
+    e isa AndExpr && return isempty(e.args) ? "true" :
+        join(("(" * _exprstr(a) * ")" for a in e.args), " & ")
+    e isa OrExpr && return isempty(e.args) ? "false" :
+        join(("(" * _exprstr(a) * ")" for a in e.args), " | ")
     e isa NotExpr && return "!(" * _exprstr(e.arg) * ")"
     e isa AlwaysTrue && return "true"
     e isa AlwaysFalse && return "false"

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -30,8 +30,8 @@
     Tables.All()
 
 Selection item matching every column (in file order). Useful combined with
-renames: `select = (:id => :key, Tables.All())` is an error (duplicate `id`) —
-use `Tables.Not(:id)` alongside instead.
+renames. `select = (:id, Tables.All())` is an error because it produces the
+output name `id` twice; renaming the explicit selection avoids that conflict.
 """
 struct All end
 
@@ -288,7 +288,9 @@ _refstr(r) = r isa Regex ? "r$(repr(r.pattern))" : repr(r)
 
 function _expand!(out::Vector{BoundColumn}, names, it::SelectItem, validate::Bool)
     r = it.ref
-    if r isa Regex
+    if r isa All
+        append!(out, BoundColumn(i, nm, it.type) for (i, nm) in enumerate(names))
+    elseif r isa Regex
         found = false
         for (i, nm) in enumerate(names)
             if occursin(r, String(nm))
@@ -349,9 +351,15 @@ function bind(scan::Scan, names)
         excluded = Set{Int}()
         for it in scan.select, r in _notrefs((it.ref::Not).ref)
             if r isa Regex
+                found = false
                 for (i, nm) in enumerate(nms)
-                    occursin(r, String(nm)) && push!(excluded, i)
+                    if occursin(r, String(nm))
+                        push!(excluded, i)
+                        found = true
+                    end
                 end
+                scan.validate && !found &&
+                    throw(ArgumentError("Not pattern $(_refstr(r)) matches no column"))
             else
                 i = _findcol(nms, r)
                 i === nothing && scan.validate &&

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -103,6 +103,8 @@ col(r::Union{Symbol, AbstractString, Int}) = Col(r isa AbstractString ? String(r
 
 const OP_EQ, OP_NE, OP_LT, OP_LE, OP_GT, OP_GE = 0x01, 0x02, 0x03, 0x04, 0x05, 0x06
 const _OPNAMES = ("==", "!=", "<", "<=", ">", ">=")
+_colcolerr() = throw(ArgumentError("column-to-column comparisons are not supported; " *
+                                   "compare a column against a literal value"))
 
 struct Cmp{T} <: ScanExpr
     op::UInt8
@@ -111,6 +113,7 @@ struct Cmp{T} <: ScanExpr
     function Cmp(op::Integer, lhs::Col, rhs::T) where {T}
         OP_EQ <= op <= OP_GE ||
             throw(ArgumentError("unknown comparison operator code $op"))
+        rhs isa Col && _colcolerr()
         return new{T}(UInt8(op), lhs, rhs)
     end
 end
@@ -138,6 +141,10 @@ colge(c::Col, value) = Cmp(OP_GE, c, value)
 struct In{T} <: ScanExpr
     lhs::Col
     values::T
+    function In(lhs::Col, values::T) where {T}
+        values isa Col && _colcolerr()
+        return new{T}(lhs, values)
+    end
 end
 
 """
@@ -203,8 +210,6 @@ struct OpNode <: ScanExpr
     args::Vector{Any}
 end
 
-_colcolerr() = throw(ArgumentError("column-to-column comparisons are not supported; " *
-                                   "compare a column against a literal value"))
 for f in (:coleq, :colne, :collt, :colle, :colgt, :colge)
     @eval $f(::Col, ::Col) = _colcolerr()
 end
@@ -238,6 +243,14 @@ Base.:!(e::IsNull) = IsNull(e.lhs, !e.negated)
 
 # a bare Col is not a predicate; catch the likely mistake early
 _checkpredicate(::Nothing) = nothing
+function _checkpredicate(e::Union{AndExpr, OrExpr})
+    foreach(_checkpredicate, e.args)
+    return e
+end
+function _checkpredicate(e::NotExpr)
+    _checkpredicate(e.arg)
+    return e
+end
 _checkpredicate(e::ScanExpr) = e
 _checkpredicate(e::Col) =
     throw(ArgumentError("a bare column reference is not a predicate; compare it against a value"))
@@ -273,6 +286,19 @@ struct Scan
     limit::Union{Nothing, Int}
     offset::Int
     validate::Bool
+    function Scan(select::Union{Nothing, Vector{SelectItem}},
+                  filter, limit::Union{Nothing, Int},
+                  offset::Int, validate::Bool)
+        limit === nothing || limit >= 0 ||
+            throw(ArgumentError("limit must be ≥ 0 (got $limit)"))
+        offset >= 0 || throw(ArgumentError("offset must be ≥ 0 (got $offset)"))
+        if select !== nothing
+            nots = count(it -> it.ref isa Not, select)
+            0 < nots < length(select) &&
+                throw(ArgumentError("Not(...) selections cannot be mixed with positive selections"))
+        end
+        return new(select, _checkpredicate(filter), limit, offset, validate)
+    end
 end
 
 function Scan(; select=nothing, filter=nothing, limit::Union{Nothing, Integer}=nothing,
@@ -280,15 +306,9 @@ function Scan(; select=nothing, filter=nothing, limit::Union{Nothing, Integer}=n
     items = select === nothing ? nothing :
             select isa Union{Tuple, AbstractVector} ? SelectItem[_selectitem(x) for x in select] :
             SelectItem[_selectitem(select)]
-    limit === nothing || limit >= 0 || throw(ArgumentError("limit must be ≥ 0 (got $limit)"))
+    lim = limit === nothing ? nothing : Int(limit)
     off = offset === nothing ? 0 : Int(offset)
-    off >= 0 || throw(ArgumentError("offset must be ≥ 0 (got $offset)"))
-    if items !== nothing
-        nots = count(it -> it.ref isa Not, items)
-        0 < nots < length(items) &&
-            throw(ArgumentError("Not(...) selections cannot be mixed with positive selections"))
-    end
-    return Scan(items, _checkpredicate(filter), limit === nothing ? nothing : Int(limit), off, validate)
+    return Scan(items, filter, lim, off, validate)
 end
 
 """
@@ -300,10 +320,14 @@ hands to `Tables.scan` after pushing the rest down: a reader that handled
 projection, types and limits itself but cannot filter does
 `Tables.scan(table, Tables.Scan(scan; select=nothing, limit=nothing, offset=0))`.
 """
-Scan(s::Scan; select=s.select, filter=s.filter, limit=s.limit, offset=s.offset,
-     validate=s.validate) = Scan(select isa Union{Nothing, Vector{SelectItem}} ? select :
-                                  Scan(; select).select,
-                                  _checkpredicate(filter), limit, Int(offset), validate)
+function Scan(s::Scan; select=s.select, filter=s.filter,
+              limit::Union{Nothing, Integer}=s.limit,
+              offset::Union{Nothing, Integer}=s.offset, validate::Bool=s.validate)
+    items = select isa Union{Nothing, Vector{SelectItem}} ? select : Scan(; select).select
+    lim = limit === nothing ? nothing : Int(limit)
+    off = offset === nothing ? 0 : Int(offset)
+    return Scan(items, filter, lim, off, validate)
+end
 
 """
     isempty(scan::Tables.Scan)
@@ -463,33 +487,37 @@ function _resolvecol(cols, ref, strict::Bool)
     return nothing
 end
 
-# three-valued vectorized evaluation; the top level keeps rows where the
-# result is exactly `true` (SQL WHERE). Comparison literals are `Ref`-wrapped
-# so collection-valued rows compare WHOLE-VALUE per row — a bare vector
-# literal must never broadcast elementwise against the column (silent
-# row-zipping when the lengths happen to match, `DimensionMismatch` when
-# they don't).
+# Three-valued vectorized evaluation; the top level keeps rows where the
+# result is exactly `true` (SQL WHERE). Comparison kernels close over their
+# literal so collection-valued rows compare whole values per row instead of
+# broadcasting the literal against the column. The fallback uses only the
+# scalar-indexing contract required by Tables.jl; the AbstractVector path
+# keeps broadcast's optimized kernels.
+_columnmap(f, c::AbstractVector, ::Int) = f.(c)
+_columnmap(f, c, n::Int) = [f(c[i]) for i in 1:n]
+
 function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
     if e isa Cmp
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
-        v = Ref(e.rhs)
-        return e.op == OP_EQ ? (a .== v) :
-               e.op == OP_NE ? (a .!= v) :
-               e.op == OP_LT ? (a .< v) :
-               e.op == OP_LE ? (a .<= v) :
-               e.op == OP_GT ? (a .> v) :
-               e.op == OP_GE ? (a .>= v) :
+        n = rowcount(cols)
+        return e.op == OP_EQ ? _columnmap(x -> x == e.rhs, a, n) :
+               e.op == OP_NE ? _columnmap(x -> x != e.rhs, a, n) :
+               e.op == OP_LT ? _columnmap(x -> x < e.rhs, a, n) :
+               e.op == OP_LE ? _columnmap(x -> x <= e.rhs, a, n) :
+               e.op == OP_GT ? _columnmap(x -> x > e.rhs, a, n) :
+               e.op == OP_GE ? _columnmap(x -> x >= e.rhs, a, n) :
                throw(ArgumentError("unknown comparison operator code $(e.op)"))
     elseif e isa In
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
-        return in.(a, Ref(e.values))
+        return _columnmap(x -> in(x, e.values), a, rowcount(cols))
     elseif e isa IsNull
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing &&
             return e.negated ? falses(rowcount(cols)) : trues(rowcount(cols))
-        return e.negated ? .!Base.ismissing.(a) : Base.ismissing.(a)
+        return e.negated ? _columnmap(x -> !Base.ismissing(x), a, rowcount(cols)) :
+                           _columnmap(Base.ismissing, a, rowcount(cols))
     elseif e isa StrPred
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
@@ -497,7 +525,7 @@ function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
             e.kind == STR_ENDSWITH ? endswith :
             e.kind == STR_CONTAINS ? contains :
             throw(ArgumentError("unknown string predicate code $(e.kind)"))
-        return map(x -> Base.ismissing(x) ? missing : f(x, e.s), a)
+        return _columnmap(x -> Base.ismissing(x) ? missing : f(x, e.s), a, rowcount(cols))
     elseif e isa AndExpr
         isempty(e.args) && return trues(rowcount(cols))
         return mapreduce(a -> _evalexpr(a, cols, strict), (x, y) -> x .& y, e.args)
@@ -529,11 +557,11 @@ all-missing column.
 # expression tree), and `Bool[x === true for x in v]` over an abstract `v`
 # melts into per-element dynamic dispatch — measured 100× slower than the
 # same loop behind a barrier (62 ms → 0.6 ms over a 1M-row mask). The
-# barrier costs ONE dynamic dispatch per mask instead. The vectorized
-# kernels inside `_evalexpr` need no such treatment: broadcast and `map`
-# already specialize on the concrete container at their own call boundary.
+# barrier costs ONE dynamic dispatch per mask instead. The column kernels
+# inside `_evalexpr` specialize on the concrete container at their own call
+# boundary.
 _boolmask(v::AbstractVector) = Bool[x === true for x in v]
-filtermask(e::ScanExpr, table) = _boolmask(_evalexpr(e, columns(table)))
+filtermask(e::ScanExpr, table) = _boolmask(_evalexpr(_checkpredicate(e), columns(table)))
 filtermask(s::Scan, table) = s.filter === nothing ?
     trues(rowcount(columns(table))) :
     _boolmask(_evalexpr(s.filter, columns(table), s.validate))
@@ -567,7 +595,7 @@ function scan(table, scan::Scan)
         keep = _boolmask(_evalexpr(scan.filter, cols, scan.validate))
         idx = findall(keep)
     else
-        idx = collect(1:rowcount(cols))
+        idx = 1:rowcount(cols)
     end
     skipped = min(scan.offset, length(idx))
     available = length(idx) - skipped

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -9,7 +9,7 @@
 # scan=Tables.Scan(...))`, `Arrow.Table(path; scan=...)` — and apply what they
 # can WHILE materializing (skipping columns never parsed, rows never decoded).
 # What a source cannot push down it either rejects with an ArgumentError, or
-# hands to `Tables.scan` as a residual (`Tables.Scan(scan; select=nothing)`
+# hands to `Tables.scan` as a residual (`Tables.Scan(scan; select=All())`
 # strips the axes it already handled). Sources are free to support only a
 # subset — the value is the shared vocabulary and the pushdown, not a
 # capability-negotiation protocol.
@@ -268,7 +268,7 @@ _checkpredicate(x) =
 # --- the Scan value --------------------------------------------------------------
 
 """
-    Tables.Scan(; select=nothing, filter=nothing, limit=nothing, offset=nothing, validate=true)
+    Tables.Scan(; select=Tables.All(), filter=nothing, limit=nothing, offset=nothing, validate=true)
 
 A scan request: what to keep, what to call it, how to type it, which rows
 qualify, and how many. Plain data all the way down — see `Tables.scan` for
@@ -277,7 +277,8 @@ the generic executor and the module comment for how sources push it down.
   * `select`: a column reference or tuple/vector of select items
     (`ref`, `ref => name`, `ref => Type`, `ref => Type => name`;
     refs are `Symbol`/`String`/`Int`/`Regex`/`Tables.Not`/`Tables.All`).
-    `nothing` keeps every column. Selection order = output order.
+    `Tables.All()` keeps every column; `()` selects zero columns. Selection
+    order = output order.
   * `filter`: an expression built from `Tables.col`; a row is kept iff the
     predicate evaluates to exactly `true` (`missing` excludes, SQL-style).
     Filters see source column names, before renames.
@@ -289,31 +290,31 @@ the generic executor and the module comment for how sources push it down.
     against it exclude, SQL-style).
 """
 struct Scan
-    select::Union{Nothing, Vector{SelectItem}}
+    select::Vector{SelectItem}
     filter::Union{Nothing, ScanExpr}
     limit::Union{Nothing, Int}
     offset::Int
     validate::Bool
-    function Scan(select::Union{Nothing, Vector{SelectItem}},
+    function Scan(select::Vector{SelectItem},
                   filter, limit::Union{Nothing, Int},
                   offset::Int, validate::Bool)
         limit === nothing || limit >= 0 ||
             throw(ArgumentError("limit must be ≥ 0 (got $limit)"))
         offset >= 0 || throw(ArgumentError("offset must be ≥ 0 (got $offset)"))
-        if select !== nothing
-            nots = count(it -> it.ref isa Not, select)
-            0 < nots < length(select) &&
-                throw(ArgumentError("Not(...) selections cannot be mixed with positive selections"))
-        end
+        nots = count(it -> it.ref isa Not, select)
+        0 < nots < length(select) &&
+            throw(ArgumentError("Not(...) selections cannot be mixed with positive selections"))
         return new(select, _checkpredicate(filter), limit, offset, validate)
     end
 end
 
-function Scan(; select=nothing, filter=nothing, limit::Union{Nothing, Integer}=nothing,
+_selectitems(select::Vector{SelectItem}) = select
+_selectitems(select::Union{Tuple, AbstractVector}) = SelectItem[_selectitem(x) for x in select]
+_selectitems(select) = SelectItem[_selectitem(select)]
+
+function Scan(; select=All(), filter=nothing, limit::Union{Nothing, Integer}=nothing,
                 offset::Union{Nothing, Integer}=nothing, validate::Bool=true)
-    items = select === nothing ? nothing :
-            select isa Union{Tuple, AbstractVector} ? SelectItem[_selectitem(x) for x in select] :
-            SelectItem[_selectitem(select)]
+    items = _selectitems(select)
     lim = limit === nothing ? nothing : Int(limit)
     off = offset === nothing ? 0 : Int(offset)
     return Scan(items, filter, lim, off, validate)
@@ -326,19 +327,25 @@ end
 Copy a scan with some axes replaced — how a source builds the RESIDUAL it
 hands to `Tables.scan` after pushing the rest down: a reader that handled
 projection, types and limits itself but cannot filter does
-`Tables.scan(table, Tables.Scan(scan; select=nothing, limit=nothing, offset=0))`.
+`Tables.scan(table, Tables.Scan(scan; select=All(), limit=nothing, offset=0))`.
 """
 function Scan(s::Scan; select=s.select, filter=s.filter,
               limit::Union{Nothing, Integer}=s.limit,
               offset::Union{Nothing, Integer}=s.offset, validate::Bool=s.validate)
-    items = select isa Union{Nothing, Vector{SelectItem}} ? select : Scan(; select).select
+    items = _selectitems(select)
     lim = limit === nothing ? nothing : Int(limit)
     off = offset === nothing ? 0 : Int(offset)
     return Scan(items, filter, lim, off, validate)
 end
 
+function _isallselection(select::Vector{SelectItem})
+    length(select) == 1 || return false
+    item = only(select)
+    return item.ref isa All && item.type === nothing && item.rename === nothing
+end
+
 _isidentity(s::Scan) =
-    s.select === nothing && s.filter === nothing && s.limit === nothing && s.offset == 0
+    _isallselection(s.select) && s.filter === nothing && s.limit === nothing && s.offset == 0
 
 
 # --- schema resolution -----------------------------------------------------------
@@ -447,7 +454,7 @@ containing only its referenced columns.
 function resolve(scan::Scan, names)
     nms = collect(Symbol, names)
     cols = BoundColumn[]
-    if scan.select === nothing
+    if _isallselection(scan.select)
         append!(cols, BoundColumn(i, nm, nothing) for (i, nm) in enumerate(nms))
     elseif !isempty(scan.select) && scan.select[1].ref isa Not
         excluded = Set{Int}()
@@ -693,7 +700,7 @@ end
 function Base.show(io::IO, s::Scan)
     print(io, "Tables.Scan(")
     parts = String[]
-    if s.select !== nothing
+    if !_isallselection(s.select)
         sel = join((begin
             r = it.ref isa Not ? "Not($(_refstr(it.ref.ref)))" :
                 it.ref isa All ? "All()" : _refstr(it.ref)

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -1,0 +1,543 @@
+# Tables.Scan: a plain-data scan request — column selection/renaming/type
+# overrides, row predicates, and limits — that any Tables.jl source can accept
+# and push down. The protocol is two functions:
+#
+#     table, residual = Tables.apply(source, scan)   # source consumes what it can
+#     table′          = Tables.finish(table, residual)  # generic layer does the rest
+#
+# with `Tables.read(source, scan)` composing the two. The default `apply`
+# pushes nothing (everything lands in the residual), so every existing
+# Tables.jl source already works — sources override `apply` to earn
+# performance, never correctness.
+#
+# Design commitments (each learned the hard way by prior systems):
+#   * Every node is a plain value — no `Function` fields anywhere. Closures are
+#     opaque to pushdown and to static compilation; expression values are not.
+#   * The source's answer is the residual itself, not a capability
+#     advertisement. Pushed and residual work may overlap (a source that
+#     prunes by a predicate but cannot guarantee exactness keeps the filter in
+#     the residual).
+#   * Missing follows SQL WHERE: a predicate evaluating to `missing` excludes
+#     the row. `isnull`/`!isnull` are first-class nodes; `==` never matches
+#     missing.
+#   * Filters reference SOURCE column names (pre-rename); the pipeline order
+#     is fixed: bind → filter → offset/limit → project/rename/type.
+#   * Selection order defines output order.
+
+# --- column references & selection items --------------------------------------
+
+"""
+    Tables.All()
+
+Selection item matching every column (in file order). Useful combined with
+renames: `select = (:id => :key, Tables.All())` is an error (duplicate `id`) —
+use `Tables.Not(:id)` alongside instead.
+"""
+struct All end
+
+"""
+    Tables.Not(ref)
+
+Selection item excluding `ref` (a name, index, `Regex`, or a `Tuple`/`Vector`
+of those) from the full column set. `Not` items cannot be mixed with positive
+selections in the same `select`.
+"""
+struct Not{T}
+    ref::T
+end
+
+const ColRef = Union{Symbol, String, Int, Regex}
+
+"""
+    Tables.SelectItem
+
+One resolved element of `Scan.select`: a column reference plus optional type
+override and output name. Users never construct these directly — the `Scan`
+constructor lowers `ref`, `ref => name`, `ref => Type`, and
+`ref => Type => name` forms.
+"""
+struct SelectItem
+    ref::Union{Symbol, String, Int, Regex, Not, All}
+    type::Union{Nothing, Type}
+    rename::Union{Nothing, Symbol}
+end
+
+_selectitem(x::Union{Symbol, String, Int, Regex, Not, All}) = SelectItem(x, nothing, nothing)
+_selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, Symbol}) = SelectItem(p.first, nothing, p.second)
+_selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, String}) = SelectItem(p.first, nothing, Symbol(p.second))
+_selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, <:Type}) = SelectItem(p.first, p.second, nothing)
+_selectitem(p::Pair{<:Union{Symbol, String, Int, Regex}, <:Pair{<:Type, Symbol}}) =
+    SelectItem(p.first, p.second.first, p.second.second)
+_selectitem(x) = throw(ArgumentError("unsupported select item $(repr(x)); expected a column " *
+    "reference (Symbol/String/Int/Regex/Not/All), or ref => name, ref => Type, ref => Type => name"))
+
+# --- the expression algebra ----------------------------------------------------
+#
+# A small closed vocabulary — the intersection every surveyed engine supports
+# and every statistics pruner can use. Growth happens through `OpNode`
+# (name + children), never through new struct kinds every consumer must learn.
+
+abstract type ScanExpr end
+
+"""
+    Tables.col(ref)
+
+A column reference inside a `Scan` filter: `col(:price) > 100`. Comparisons
+against literals, `in_`, `isnull`, `startswith`/`endswith`/`contains`, and
+`&`/`|`/`!` build plain expression values.
+"""
+struct Col <: ScanExpr
+    ref::Union{Symbol, String, Int}
+end
+col(r::Union{Symbol, AbstractString, Int}) = Col(r isa AbstractString ? String(r) : r)
+
+const OP_EQ, OP_NE, OP_LT, OP_LE, OP_GT, OP_GE = 0x01, 0x02, 0x03, 0x04, 0x05, 0x06
+const _OPNAMES = ("==", "!=", "<", "<=", ">", ">=")
+
+struct Cmp{T} <: ScanExpr
+    op::UInt8
+    lhs::Col
+    rhs::T
+end
+
+struct In{T} <: ScanExpr
+    lhs::Col
+    values::T
+end
+
+"""
+    Tables.in_(col, values)
+
+Membership predicate: `in_(col(:status), ("active", "trial"))`.
+"""
+in_(c::Col, values) = In(c, values)
+
+struct IsNull <: ScanExpr
+    lhs::Col
+    negated::Bool
+end
+
+"""
+    Tables.isnull(col)
+
+Missing-ness predicate. Use this — never `col(:x) == missing`, which follows
+SQL semantics and matches no row.
+"""
+isnull(c::Col) = IsNull(c, false)
+
+const STR_STARTSWITH, STR_ENDSWITH, STR_CONTAINS = 0x01, 0x02, 0x03
+
+struct StrPred <: ScanExpr
+    kind::UInt8
+    lhs::Col
+    s::String
+end
+
+struct AndExpr <: ScanExpr
+    args::Vector{ScanExpr}
+end
+struct OrExpr <: ScanExpr
+    args::Vector{ScanExpr}
+end
+struct NotExpr <: ScanExpr
+    arg::ScanExpr
+end
+struct AlwaysTrue <: ScanExpr end
+struct AlwaysFalse <: ScanExpr end
+
+"""
+    Tables.OpNode(name, args)
+
+The expression algebra's growth channel: a named node with child values.
+Sources that recognize `name` may push it down; the generic executor rejects
+unknown names, so new operations deploy source-first without new node types.
+"""
+struct OpNode <: ScanExpr
+    name::Symbol
+    args::Vector{Any}
+end
+
+_colcolerr() = throw(ArgumentError("column-to-column comparisons are not supported; " *
+                                   "compare a column against a literal value"))
+for (f, op) in ((:(==), :OP_EQ), (:<, :OP_LT), (:<=, :OP_LE), (:>, :OP_GT), (:>=, :OP_GE))
+    revop = f === :(==) ? :OP_EQ : f === :< ? :OP_GT : f === :<= ? :OP_GE :
+            f === :> ? :OP_LT : :OP_LE
+    @eval begin
+        Base.$f(c::Col, v) = Cmp($op, c, v)
+        Base.$f(v, c::Col) = Cmp($revop, c, v)
+        Base.$f(::Col, ::Col) = _colcolerr()
+    end
+end
+Base.:(!=)(c::Col, v) = NotExpr(Cmp(OP_EQ, c, v))
+Base.:(!=)(v, c::Col) = NotExpr(Cmp(OP_EQ, c, v))
+Base.:(!=)(::Col, ::Col) = _colcolerr()
+Base.isequal(c::Col, v) = Cmp(OP_EQ, c, v)   # convenience alias; == semantics
+
+Base.startswith(c::Col, s::AbstractString) = StrPred(STR_STARTSWITH, c, String(s))
+Base.endswith(c::Col, s::AbstractString) = StrPred(STR_ENDSWITH, c, String(s))
+Base.contains(c::Col, s::AbstractString) = StrPred(STR_CONTAINS, c, String(s))
+Base.in(c::Col, values) = In(c, values)
+
+_ands(e::AndExpr) = e.args
+_ands(e::ScanExpr) = ScanExpr[e]
+_ors(e::OrExpr) = e.args
+_ors(e::ScanExpr) = ScanExpr[e]
+Base.:&(a::ScanExpr, b::ScanExpr) = AndExpr(vcat(_ands(a), _ands(b)))
+Base.:|(a::ScanExpr, b::ScanExpr) = OrExpr(vcat(_ors(a), _ors(b)))
+Base.:!(e::ScanExpr) = NotExpr(e)
+Base.:!(e::NotExpr) = e.arg
+Base.:!(e::IsNull) = IsNull(e.lhs, !e.negated)
+
+# a bare Col is not a predicate; catch the likely mistake early
+_checkpredicate(::Nothing) = nothing
+_checkpredicate(e::ScanExpr) = e
+_checkpredicate(e::Col) =
+    throw(ArgumentError("a bare column reference is not a predicate; compare it against a value"))
+_checkpredicate(x) =
+    throw(ArgumentError("filter must be a Tables.Scan expression (built from Tables.col), got $(typeof(x))"))
+
+# --- the Scan value --------------------------------------------------------------
+
+"""
+    Tables.Scan(; select=nothing, filter=nothing, limit=nothing, offset=nothing, validate=true)
+
+A scan request: what to keep, what to call it, how to type it, which rows
+qualify, and how many. Plain data all the way down — see `Tables.apply`,
+`Tables.finish`, and `Tables.read` for the protocol.
+
+  * `select`: a column reference or tuple/vector of select items
+    (`ref`, `ref => name`, `ref => Type`, `ref => Type => name`;
+    refs are `Symbol`/`String`/`Int`/`Regex`/`Tables.Not`/`Tables.All`).
+    `nothing` keeps every column. Selection order = output order.
+  * `filter`: an expression built from `Tables.col`; a row is kept iff the
+    predicate evaluates to exactly `true` (`missing` excludes, SQL-style).
+    Filters see source column names, before renames.
+  * `limit`/`offset`: applied to qualifying rows, after the filter.
+  * `validate`: error on select/filter references that match no column
+    (`false` silently drops unmatched names — the schema-evolution knob).
+"""
+struct Scan
+    select::Union{Nothing, Vector{SelectItem}}
+    filter::Union{Nothing, ScanExpr}
+    limit::Union{Nothing, Int}
+    offset::Int
+    validate::Bool
+end
+
+function Scan(; select=nothing, filter=nothing, limit::Union{Nothing, Integer}=nothing,
+                offset::Union{Nothing, Integer}=nothing, validate::Bool=true)
+    items = select === nothing ? nothing :
+            select isa Union{Tuple, AbstractVector} ? SelectItem[_selectitem(x) for x in select] :
+            SelectItem[_selectitem(select)]
+    limit === nothing || limit >= 0 || throw(ArgumentError("limit must be ≥ 0 (got $limit)"))
+    off = offset === nothing ? 0 : Int(offset)
+    off >= 0 || throw(ArgumentError("offset must be ≥ 0 (got $offset)"))
+    if items !== nothing
+        nots = count(it -> it.ref isa Not, items)
+        0 < nots < length(items) &&
+            throw(ArgumentError("Not(...) selections cannot be mixed with positive selections"))
+    end
+    return Scan(items, _checkpredicate(filter), limit === nothing ? nothing : Int(limit), off, validate)
+end
+
+"""
+    isempty(scan::Tables.Scan)
+
+`true` when the scan requests nothing: no selection, no filter, no limit or
+offset. `Tables.finish` returns the table unchanged for an empty residual.
+"""
+Base.isempty(s::Scan) =
+    s.select === nothing && s.filter === nothing && s.limit === nothing && s.offset == 0
+
+# an all-consumed residual, for sources that push everything down
+const EMPTYSCAN = Scan(nothing, nothing, nothing, 0, true)
+
+# --- binding ---------------------------------------------------------------------
+
+"""
+    Tables.BoundColumn
+
+One output column after `Tables.bind`: the source column index, the output
+name (post-rename, uniqueness enforced), and the optional type override.
+"""
+struct BoundColumn
+    index::Int
+    name::Symbol
+    type::Union{Nothing, Type}
+end
+
+"""
+    Tables.BoundScan
+
+A `Scan` resolved against a concrete schema: output columns in order, the
+(validated) filter with the source column indices it references, and the
+row bounds. Sources consume this, not the raw `Scan`.
+"""
+struct BoundScan
+    columns::Vector{BoundColumn}
+    filter::Union{Nothing, ScanExpr}
+    filtercols::Vector{Int}
+    limit::Union{Nothing, Int}
+    offset::Int
+end
+
+_findcol(names, r::Symbol) = findfirst(==(r), names)
+_findcol(names, r::String) = findfirst(==(Symbol(r)), names)
+_findcol(names, r::Int) = 1 <= r <= length(names) ? r : nothing
+_refstr(r) = r isa Regex ? "r$(repr(r.pattern))" : repr(r)
+
+function _expand!(out::Vector{BoundColumn}, names, it::SelectItem, validate::Bool)
+    r = it.ref
+    if r isa Regex
+        found = false
+        for (i, nm) in enumerate(names)
+            if occursin(r, String(nm))
+                push!(out, BoundColumn(i, it.rename === nothing ? nm : it.rename, it.type))
+                found = true
+            end
+        end
+        validate && !found &&
+            throw(ArgumentError("select pattern $(_refstr(r)) matches no column"))
+        found && it.rename !== nothing && count(c -> c.name == it.rename, out) > 1 &&
+            throw(ArgumentError("pattern rename $(repr(it.rename)) applies to multiple columns"))
+    else
+        i = _findcol(names, r)
+        if i === nothing
+            validate && throw(ArgumentError("select reference $(_refstr(r)) matches no column " *
+                                            "(pass validate=false to skip unmatched references)"))
+            return
+        end
+        push!(out, BoundColumn(i, it.rename === nothing ? names[i] : it.rename, it.type))
+    end
+    return
+end
+
+_notrefs(x::Union{Tuple, AbstractVector}) = collect(Any, x)
+_notrefs(x) = Any[x]
+
+function _filterrefs!(refs::Vector{Int}, e::ScanExpr, names, validate::Bool)
+    if e isa Union{Cmp, In, IsNull, StrPred}
+        i = _findcol(names, e.lhs.ref)
+        i === nothing && validate &&
+            throw(ArgumentError("filter references unknown column $(_refstr(e.lhs.ref))"))
+        i === nothing || (i in refs || push!(refs, i))
+    elseif e isa AndExpr || e isa OrExpr
+        foreach(a -> _filterrefs!(refs, a, names, validate), e.args)
+    elseif e isa NotExpr
+        _filterrefs!(refs, e.arg, names, validate)
+    elseif e isa OpNode
+        throw(ArgumentError("cannot bind extension node $(repr(e.name)): no generic evaluation; " *
+                            "only sources that recognize it may consume it"))
+    end
+    return refs
+end
+
+"""
+    Tables.bind(scan::Scan, names) -> BoundScan
+
+Resolve a `Scan` against a source's column names (any iterable of `Symbol`s).
+Errors on unmatched references (under `validate`), mixed `Not`/positive
+selections, and duplicate output names. Regex references expand in file
+order; selection order defines output order.
+"""
+function bind(scan::Scan, names)
+    nms = collect(Symbol, names)
+    cols = BoundColumn[]
+    if scan.select === nothing
+        append!(cols, BoundColumn(i, nm, nothing) for (i, nm) in enumerate(nms))
+    elseif !isempty(scan.select) && scan.select[1].ref isa Not
+        excluded = Set{Int}()
+        for it in scan.select, r in _notrefs((it.ref::Not).ref)
+            if r isa Regex
+                for (i, nm) in enumerate(nms)
+                    occursin(r, String(nm)) && push!(excluded, i)
+                end
+            else
+                i = _findcol(nms, r)
+                i === nothing && scan.validate &&
+                    throw(ArgumentError("Not reference $(_refstr(r)) matches no column"))
+                i === nothing || push!(excluded, i)
+            end
+        end
+        append!(cols, BoundColumn(i, nm, nothing) for (i, nm) in enumerate(nms) if !(i in excluded))
+    else
+        foreach(it -> _expand!(cols, nms, it, scan.validate), scan.select)
+    end
+    seen = Set{Symbol}()
+    for c in cols
+        c.name in seen && throw(ArgumentError("duplicate output column name $(repr(c.name)); " *
+                                              "rename one of the selections"))
+        push!(seen, c.name)
+    end
+    refs = Int[]
+    scan.filter === nothing || _filterrefs!(refs, scan.filter, nms, scan.validate)
+    return BoundScan(cols, scan.filter, refs, scan.limit, scan.offset)
+end
+
+# --- generic evaluation ------------------------------------------------------------
+
+_getcol(cols, ref::Symbol) = getcolumn(cols, ref)
+_getcol(cols, ref::String) = getcolumn(cols, Symbol(ref))
+_getcol(cols, ref::Int) = getcolumn(cols, ref)
+
+# three-valued vectorized evaluation; the top level keeps rows where the
+# result is exactly `true` (SQL WHERE)
+function _evalexpr(e::ScanExpr, cols)
+    if e isa Cmp
+        a = _getcol(cols, e.lhs.ref)
+        v = e.rhs
+        return e.op == OP_EQ ? (a .== v) :
+               e.op == OP_LT ? (a .< v) :
+               e.op == OP_LE ? (a .<= v) :
+               e.op == OP_GT ? (a .> v) : (a .>= v)
+    elseif e isa In
+        a = _getcol(cols, e.lhs.ref)
+        return in.(a, Ref(e.values))
+    elseif e isa IsNull
+        a = _getcol(cols, e.lhs.ref)
+        return e.negated ? .!ismissing.(a) : ismissing.(a)
+    elseif e isa StrPred
+        a = _getcol(cols, e.lhs.ref)
+        f = e.kind == STR_STARTSWITH ? startswith :
+            e.kind == STR_ENDSWITH ? endswith : contains
+        return map(x -> ismissing(x) ? missing : f(x, e.s), a)
+    elseif e isa AndExpr
+        return mapreduce(a -> _evalexpr(a, cols), (x, y) -> x .& y, e.args)
+    elseif e isa OrExpr
+        return mapreduce(a -> _evalexpr(a, cols), (x, y) -> x .| y, e.args)
+    elseif e isa NotExpr
+        return .!_evalexpr(e.arg, cols)
+    elseif e isa AlwaysTrue
+        return trues(rowcount(cols))
+    elseif e isa AlwaysFalse
+        return falses(rowcount(cols))
+    end
+    throw(ArgumentError("cannot generically evaluate $(typeof(e))"))
+end
+
+"""
+    Tables.filtermask(scan_or_expr, table) -> Vector{Bool}
+
+Evaluate a scan's filter over a table's columns: `mask[i]` is `true` iff row
+`i` qualifies (a `missing` predicate result excludes the row). Sources use
+this for their own pushdown implementations.
+"""
+filtermask(e::ScanExpr, table) = Bool[x === true for x in _evalexpr(e, columns(table))]
+filtermask(s::Scan, table) = s.filter === nothing ?
+    trues(rowcount(columns(table))) : filtermask(s.filter, table)
+
+_converted(::Nothing, c::AbstractVector) = c
+function _converted(::Type{T}, c::AbstractVector) where {T}
+    eltype(c) <: Union{T, Missing} && return c
+    anymissing = any(ismissing, c)
+    E = anymissing ? Union{T, Missing} : T
+    return E[ismissing(x) ? missing : convert(T, x) for x in c]
+end
+
+"""
+    Tables.finish(table, residual::Scan) -> table′
+
+Apply whatever a source did NOT push down, generically, over any Tables.jl
+table: filter (SQL missing semantics), offset/limit, projection, renames, and
+type overrides (elementwise `convert` — a source that consumes `types` itself,
+like a CSV parser, never leaves them in the residual). Returns the table
+unchanged when the residual is empty; otherwise a `NamedTuple` of columns.
+"""
+function finish(table, scan::Scan)
+    isempty(scan) && return table
+    cols = columns(table)
+    b = bind(scan, columnnames(cols))
+    if scan.filter !== nothing
+        keep = Bool[x === true for x in _evalexpr(scan.filter, cols)]
+        idx = findall(keep)
+    else
+        idx = collect(1:rowcount(cols))
+    end
+    lo = scan.offset + 1
+    hi = scan.limit === nothing ? length(idx) : min(length(idx), scan.offset + scan.limit)
+    idx = idx[lo:max(hi, lo - 1)]
+    outnames = Tuple(c.name for c in b.columns)
+    outcols = Tuple(_converted(c.type, getcolumn(cols, c.index)[idx]) for c in b.columns)
+    return NamedTuple{outnames}(outcols)
+end
+
+# --- the protocol -----------------------------------------------------------------
+
+"""
+    Tables.apply(source, scan::Scan) -> (table, residual::Scan)
+
+Sources override this to push down whatever parts of `scan` they can, and
+return the rest as a residual for `Tables.finish`. The fallback pushes
+nothing, so every Tables.jl source works unmodified. Contract:
+
+  * `Tables.finish(Tables.apply(src, scan)...)` must equal
+    `Tables.finish(Tables.columns(src), scan)` (up to table type).
+  * Pushed and residual work may overlap: a source that used a predicate to
+    prune inexactly (chunks, row groups) keeps that predicate in the residual.
+  * A source may consume `limit`/`offset` only if every filter it applied was
+    exact — inexact filtering poisons limit pushdown.
+  * Contradictions error (an unknown selected column under `validate`, a type
+    override conflicting with a source-fixed schema); mere inability never
+    errors — it lands in the residual.
+"""
+apply(source, scan::Scan) = (source, scan)
+
+"""
+    Tables.read(source, scan::Scan)
+
+`Tables.finish(Tables.apply(source, scan)...)` — the one-call entry point.
+"""
+function read(source, scan::Scan)
+    t, residual = apply(source, scan)
+    return finish(t, residual)
+end
+
+# --- display -----------------------------------------------------------------------
+
+function _exprstr(e::ScanExpr)
+    e isa Cmp && return "col($(repr(e.lhs.ref))) $(_OPNAMES[e.op]) $(repr(e.rhs))"
+    e isa In && return "in_(col($(repr(e.lhs.ref))), $(repr(e.values)))"
+    e isa IsNull && return (e.negated ? "!isnull(" : "isnull(") * "col($(repr(e.lhs.ref))))"
+    e isa StrPred && return (e.kind == STR_STARTSWITH ? "startswith" :
+                             e.kind == STR_ENDSWITH ? "endswith" : "contains") *
+                            "(col($(repr(e.lhs.ref))), $(repr(e.s)))"
+    e isa AndExpr && return join(("(" * _exprstr(a) * ")" for a in e.args), " & ")
+    e isa OrExpr && return join(("(" * _exprstr(a) * ")" for a in e.args), " | ")
+    e isa NotExpr && return "!(" * _exprstr(e.arg) * ")"
+    e isa AlwaysTrue && return "true"
+    e isa AlwaysFalse && return "false"
+    e isa OpNode && return "OpNode($(repr(e.name)), …)"
+    return string(e)
+end
+
+function Base.show(io::IO, s::Scan)
+    print(io, "Tables.Scan(")
+    parts = String[]
+    if s.select !== nothing
+        sel = join((begin
+            r = it.ref isa Not ? "Not($(_refstr(it.ref.ref)))" :
+                it.ref isa All ? "All()" : _refstr(it.ref)
+            it.type !== nothing && (r *= " => $(it.type)")
+            it.rename !== nothing && (r *= " => $(repr(it.rename))")
+            r
+        end for it in s.select), ", ")
+        push!(parts, "select = ($sel)")
+    end
+    s.filter === nothing || push!(parts, "filter = " * _exprstr(s.filter))
+    s.limit === nothing || push!(parts, "limit = $(s.limit)")
+    s.offset == 0 || push!(parts, "offset = $(s.offset)")
+    s.validate || push!(parts, "validate = false")
+    print(io, join(parts, ", "), ")")
+end
+
+"""
+    Tables.describe([io,] scan, residual)
+
+Print what a source pushed down versus what remains for the generic layer —
+the EXPLAIN affordance for pushdown debugging.
+"""
+function describe(io::IO, scan::Scan, residual::Scan)
+    println(io, "scan:     ", scan)
+    println(io, "residual: ", isempty(residual) ? "(empty — fully pushed down)" : residual)
+end
+describe(scan::Scan, residual::Scan) = describe(stdout, scan, residual)

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -508,10 +508,19 @@ strict about unknown column references; the `Scan` form follows the scan's
 `validate` — under `validate=false` an unmatched reference evaluates as an
 all-missing column.
 """
-filtermask(e::ScanExpr, table) = Bool[x === true for x in _evalexpr(e, columns(table))]
+# The Bool-mask comprehension runs behind a FUNCTION BARRIER: `_evalexpr`
+# returns an abstractly-typed vector (its result type depends on the
+# expression tree), and `Bool[x === true for x in v]` over an abstract `v`
+# melts into per-element dynamic dispatch — measured 100× slower than the
+# same loop behind a barrier (62 ms → 0.6 ms over a 1M-row mask). The
+# barrier costs ONE dynamic dispatch per mask instead. The vectorized
+# kernels inside `_evalexpr` need no such treatment: broadcast and `map`
+# already specialize on the concrete container at their own call boundary.
+_boolmask(v::AbstractVector) = Bool[x === true for x in v]
+filtermask(e::ScanExpr, table) = _boolmask(_evalexpr(e, columns(table)))
 filtermask(s::Scan, table) = s.filter === nothing ?
     trues(rowcount(columns(table))) :
-    Bool[x === true for x in _evalexpr(s.filter, columns(table), s.validate)]
+    _boolmask(_evalexpr(s.filter, columns(table), s.validate))
 
 _converted(::Nothing, c::AbstractVector) = c
 function _converted(::Type{T}, c::AbstractVector) where {T}
@@ -538,7 +547,7 @@ function finish(table, scan::Scan)
     cols = columns(table)
     b = bind(scan, columnnames(cols))
     if scan.filter !== nothing
-        keep = Bool[x === true for x in _evalexpr(scan.filter, cols, scan.validate)]
+        keep = _boolmask(_evalexpr(scan.filter, cols, scan.validate))
         idx = findall(keep)
     else
         idx = collect(1:rowcount(cols))

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -18,7 +18,7 @@
 #     prunes by a predicate but cannot guarantee exactness keeps the filter in
 #     the residual).
 #   * Missing follows SQL WHERE: a predicate evaluating to `missing` excludes
-#     the row. `ismissing`/`!ismissing` are first-class nodes; `coleq` never
+#     the row. `isnull`/`!isnull` are first-class nodes; `coleq` never
 #     matches missing.
 #   * Filters reference SOURCE column names (pre-rename); the pipeline order
 #     is fixed: bind → filter → offset/limit → project/rename/type.
@@ -89,7 +89,7 @@ abstract type ScanExpr end
     Tables.col(ref)
 
 A column reference inside a `Scan` filter: `col(:price) > 100`. Comparisons
-against literals, `in_`, `ismissing`, `startswith`/`endswith`/`contains`, and
+against literals, `in_`, `isnull`, `startswith`/`endswith`/`contains`, and
 `&`/`|`/`!` build plain expression values.
 """
 struct Col <: ScanExpr
@@ -143,21 +143,24 @@ Membership predicate: `in_(col(:status), ("active", "trial"))`.
 """
 in_(c::Col, values) = In(c, values)
 
-struct IsMissing <: ScanExpr
+struct IsNull <: ScanExpr
     lhs::Col
     negated::Bool
 end
 
 """
-    Tables.ismissing(col)
+    Tables.isnull(col)
 
-Missing-ness predicate. Use this rather than `coleq(col(:x), missing)`, which
+Build a predicate that is true when the column value is Julia's `missing`.
+Use `!Tables.isnull(col)` to match values that are not `missing`.
+
+The `isnull` name is deliberate. Defining `Base.ismissing(::Col)` would
+specialize Base's broad fallback and invalidate unrelated precompiled code
+when Tables loads. Use `isnull` rather than `coleq(col(:x), missing)`, which
 follows SQL semantics and matches no row.
 """
-# Keep this function Tables-local. Base.ismissing has an Any fallback, so a Col
-# method there invalidates unrelated precompiled code.
-function ismissing end
-ismissing(c::Col) = IsMissing(c, false)
+function isnull end
+isnull(c::Col) = IsNull(c, false)
 
 const STR_STARTSWITH, STR_ENDSWITH, STR_CONTAINS = 0x01, 0x02, 0x03
 
@@ -227,7 +230,7 @@ Base.:&(a::ScanExpr, b::ScanExpr) = AndExpr(vcat(_ands(a), _ands(b)))
 Base.:|(a::ScanExpr, b::ScanExpr) = OrExpr(vcat(_ors(a), _ors(b)))
 Base.:!(e::ScanExpr) = NotExpr(e)
 Base.:!(e::NotExpr) = e.arg
-Base.:!(e::IsMissing) = IsMissing(e.lhs, !e.negated)
+Base.:!(e::IsNull) = IsNull(e.lhs, !e.negated)
 
 # a bare Col is not a predicate; catch the likely mistake early
 _checkpredicate(::Nothing) = nothing
@@ -257,7 +260,7 @@ qualify, and how many. Plain data all the way down — see `Tables.apply`,
   * `validate`: error on select/filter references that match no column.
     `false` is the schema-evolution knob: unmatched SELECT references are
     silently dropped, and an unmatched FILTER reference evaluates as an
-    all-missing column (`ismissing(col(:gone))` keeps every row; comparisons
+    all-missing column (`isnull(col(:gone))` keeps every row; comparisons
     against it exclude, SQL-style).
 """
 struct Scan
@@ -362,7 +365,7 @@ _notrefs(x::Union{Tuple, AbstractVector}) = collect(Any, x)
 _notrefs(x) = Any[x]
 
 function _filterrefs!(refs::Vector{Int}, e::ScanExpr, names, validate::Bool)
-    if e isa Union{Cmp, In, IsMissing, StrPred}
+    if e isa Union{Cmp, In, IsNull, StrPred}
         i = _findcol(names, e.lhs.ref)
         i === nothing && validate &&
             throw(ArgumentError("filter references unknown column $(_refstr(e.lhs.ref))"))
@@ -435,7 +438,7 @@ _getcol(cols, ref::Int) = getcolumn(cols, ref)
 # Resolve a filter leaf's column. Under `strict` an unknown reference is an
 # error; otherwise it resolves to `nothing` and the leaf evaluates as an
 # ALL-MISSING column — the schema-evolution semantics: a column this table
-# does not have reads as missing everywhere (`ismissing` keeps every row, every
+# does not have reads as missing everywhere (`isnull` keeps every row, every
 # comparison excludes, and three-valued `&`/`|` compose from there).
 function _resolvecol(cols, ref, strict::Bool)
     i = _findcol(columnnames(cols), ref)
@@ -466,7 +469,7 @@ function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
         return in.(a, Ref(e.values))
-    elseif e isa IsMissing
+    elseif e isa IsNull
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing &&
             return e.negated ? falses(rowcount(cols)) : trues(rowcount(cols))
@@ -588,7 +591,7 @@ end
 function _exprstr(e::ScanExpr)
     e isa Cmp && return "col($(repr(e.lhs.ref))) $(_OPNAMES[e.op]) $(repr(e.rhs))"
     e isa In && return "in_(col($(repr(e.lhs.ref))), $(repr(e.values)))"
-    e isa IsMissing && return (e.negated ? "!ismissing(" : "ismissing(") * "col($(repr(e.lhs.ref))))"
+    e isa IsNull && return (e.negated ? "!isnull(" : "isnull(") * "col($(repr(e.lhs.ref))))"
     e isa StrPred && return (e.kind == STR_STARTSWITH ? "startswith" :
                              e.kind == STR_ENDSWITH ? "endswith" : "contains") *
                             "(col($(repr(e.lhs.ref))), $(repr(e.s)))"

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -1,14 +1,18 @@
 # Tables.Scan: a plain-data scan request — column selection/renaming/type
-# overrides, row predicates, and limits — that any Tables.jl source can accept
-# and push down. The protocol is two functions:
+# overrides, row predicates, and limits — one shared vocabulary that any
+# data source can accept and push down. Two pieces:
 #
-#     table, residual = Tables.apply(source, scan)   # source consumes what it can
-#     table′          = Tables.finish(table, residual)  # generic layer does the rest
+#     Tables.Scan(...)             the request (a value; no Function fields)
+#     Tables.scan(table, scan)     the generic executor over any Tables.jl table
 #
-# with `Tables.scan(source, scan)` composing the two. The default `apply`
-# pushes nothing (everything lands in the residual), so every existing
-# Tables.jl source already works — sources override `apply` to earn
-# performance, never correctness.
+# Sources that can push a scan down accept it as a keyword — `CSV.File(path;
+# scan=Tables.Scan(...))`, `Arrow.Table(path; scan=...)` — and apply what they
+# can WHILE materializing (skipping columns never parsed, rows never decoded).
+# What a source cannot push down it either rejects with an ArgumentError, or
+# hands to `Tables.scan` as a residual (`Tables.Scan(scan; select=nothing)`
+# strips the axes it already handled). Sources are free to support only a
+# subset — the value is the shared vocabulary and the pushdown, not a
+# capability-negotiation protocol.
 #
 # Design commitments (each learned the hard way by prior systems):
 #   * Every node is a plain value — no `Function` fields anywhere. Closures are
@@ -246,8 +250,8 @@ _checkpredicate(x) =
     Tables.Scan(; select=nothing, filter=nothing, limit=nothing, offset=nothing, validate=true)
 
 A scan request: what to keep, what to call it, how to type it, which rows
-qualify, and how many. Plain data all the way down — see `Tables.apply`,
-`Tables.finish`, and `Tables.scan` for the protocol.
+qualify, and how many. Plain data all the way down — see `Tables.scan` for
+the generic executor and the module comment for how sources push it down.
 
   * `select`: a column reference or tuple/vector of select items
     (`ref`, `ref => name`, `ref => Type`, `ref => Type => name`;
@@ -288,16 +292,28 @@ function Scan(; select=nothing, filter=nothing, limit::Union{Nothing, Integer}=n
 end
 
 """
+    Tables.Scan(scan::Scan; select=scan.select, filter=scan.filter,
+                limit=scan.limit, offset=scan.offset, validate=scan.validate)
+
+Copy a scan with some axes replaced — how a source builds the RESIDUAL it
+hands to `Tables.scan` after pushing the rest down: a reader that handled
+projection, types and limits itself but cannot filter does
+`Tables.scan(table, Tables.Scan(scan; select=nothing, limit=nothing, offset=0))`.
+"""
+Scan(s::Scan; select=s.select, filter=s.filter, limit=s.limit, offset=s.offset,
+     validate=s.validate) = Scan(select isa Union{Nothing, Vector{SelectItem}} ? select :
+                                  Scan(; select).select,
+                                  _checkpredicate(filter), limit, Int(offset), validate)
+
+"""
     isempty(scan::Tables.Scan)
 
 `true` when the scan requests nothing: no selection, no filter, no limit or
-offset. `Tables.finish` returns the table unchanged for an empty residual.
+offset. `Tables.scan` returns the table unchanged for an empty scan.
 """
 Base.isempty(s::Scan) =
     s.select === nothing && s.filter === nothing && s.limit === nothing && s.offset == 0
 
-# an all-consumed residual, for sources that push everything down
-const EMPTYSCAN = Scan(nothing, nothing, nothing, 0, true)
 
 # --- binding ---------------------------------------------------------------------
 
@@ -534,15 +550,16 @@ _takecolumn(c::AbstractVector, idx) = c[idx]
 _takecolumn(c, idx) = [c[i] for i in idx]
 
 """
-    Tables.finish(table, residual::Scan) -> table′
+    Tables.scan(table, scan::Scan) -> table′
 
-Apply whatever a source did NOT push down, generically, over any Tables.jl
-table: filter (SQL missing semantics), offset/limit, projection, renames, and
-type overrides (elementwise `convert` — a source that consumes `types` itself,
-like a CSV parser, never leaves them in the residual). Returns the table
-unchanged when the residual is empty; otherwise a `NamedTuple` of columns.
+Apply a `Scan` generically over ANY Tables.jl table: filter (SQL missing
+semantics: a predicate evaluating to `missing` excludes the row), then
+offset/limit, then projection, renames, and type overrides (elementwise
+`convert`). Returns the table unchanged when the scan is empty; otherwise a
+`NamedTuple` of columns. This is the reference semantics every pushdown
+must agree with, and the executor sources hand their residual to.
 """
-function finish(table, scan::Scan)
+function scan(table, scan::Scan)
     isempty(scan) && return table
     cols = columns(table)
     b = bind(scan, columnnames(cols))
@@ -559,40 +576,6 @@ function finish(table, scan::Scan)
     outnames = Tuple(c.name for c in b.columns)
     outcols = Tuple(_converted(c.type, _takecolumn(getcolumn(cols, c.index), idx)) for c in b.columns)
     return NamedTuple{outnames}(outcols)
-end
-
-# --- the protocol -----------------------------------------------------------------
-
-"""
-    Tables.apply(source, scan::Scan) -> (table, residual::Scan)
-
-Sources override this to push down whatever parts of `scan` they can, and
-return the rest as a residual for `Tables.finish`. The fallback pushes
-nothing, so every Tables.jl source works unmodified. Contract:
-
-  * `Tables.finish(Tables.apply(src, scan)...)` must equal
-    `Tables.finish(Tables.columns(src), scan)` (up to table type).
-  * Pushed and residual work may overlap: a source that used a predicate to
-    prune inexactly (chunks, row groups) keeps that predicate in the residual.
-  * A source may consume `limit`/`offset` only if every filter it applied was
-    exact — inexact filtering poisons limit pushdown.
-  * Contradictions error (an unknown selected column under `validate`, a type
-    override conflicting with a source-fixed schema); mere inability never
-    errors — it lands in the residual.
-"""
-apply(source, scan::Scan) = (source, scan)
-
-"""
-    Tables.scan(source, scan::Scan)
-
-`Tables.finish(Tables.apply(source, scan)...)` — the one-call entry point.
-Sources that push scans down (a CSV reader, a database) implement
-`Tables.apply`; `Tables.scan` composes it with the generic `finish` so
-callers never see the residual.
-"""
-function scan(source, s::Scan)
-    t, residual = apply(source, s)
-    return finish(t, residual)
 end
 
 # --- display -----------------------------------------------------------------------
@@ -638,8 +621,8 @@ end
 """
     Tables.describe([io,] scan, residual)
 
-Print what a source pushed down versus what remains for the generic layer —
-the EXPLAIN affordance for pushdown debugging.
+Print a scan next to the residual a source handed to `Tables.scan` — the
+EXPLAIN affordance for pushdown debugging.
 """
 function describe(io::IO, scan::Scan, residual::Scan)
     println(io, "scan:     ", scan)

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -22,22 +22,15 @@
 #     prunes by a predicate but cannot guarantee exactness keeps the filter in
 #     the residual).
 #   * Missing follows SQL WHERE: a predicate evaluating to `missing` excludes
-#     the row. `isnull`/`!isnull` are first-class nodes; `coleq` never
-#     matches missing.
+#     the row. `isnull`/`!isnull` are first-class nodes; comparisons never
+#     match missing.
 #   * Filters reference SOURCE column names (pre-rename); the pipeline order
-#     is fixed: bind → filter → offset/limit → project/rename/type.
+#     is fixed: resolve → filter → offset/limit → project/rename/type.
 #   * Selection order defines output order.
 
 # --- column references & selection items --------------------------------------
 
-"""
-    Tables.All()
-
-Selection item matching every column (in file order). Useful combined with
-renames. `select = (:id, Tables.All())` is an error because it produces the
-output name `id` twice; renaming the explicit selection avoids that conflict.
-"""
-struct All end
+import DataAPI: All
 
 """
     Tables.Not(ref)
@@ -89,54 +82,64 @@ _selectitem(x) = throw(ArgumentError("unsupported select item $(repr(x)); expect
 
 abstract type ScanExpr end
 
+struct Col <: ScanExpr
+    ref::Union{Symbol, String, Int}
+end
 """
     Tables.col(ref)
 
 A column reference inside a `Scan` filter: `col(:price) > 100`. Comparisons
-against literals, `in_`, `isnull`, `startswith`/`endswith`/`contains`, and
+against literals, `colin`, `isnull`, `startswith`/`endswith`/`contains`, and
 `&`/`|`/`!` build plain expression values.
 """
-struct Col <: ScanExpr
-    ref::Union{Symbol, String, Int}
-end
 col(r::Union{Symbol, AbstractString, Int}) = Col(r isa AbstractString ? String(r) : r)
 
-const OP_EQ, OP_NE, OP_LT, OP_LE, OP_GT, OP_GE = 0x01, 0x02, 0x03, 0x04, 0x05, 0x06
+@enum ComparisonOperator::UInt8 begin
+    OP_EQ = 0x01
+    OP_NE = 0x02
+    OP_LT = 0x03
+    OP_LE = 0x04
+    OP_GT = 0x05
+    OP_GE = 0x06
+end
 const _OPNAMES = ("==", "!=", "<", "<=", ">", ">=")
 _colcolerr() = throw(ArgumentError("column-to-column comparisons are not supported; " *
                                    "compare a column against a literal value"))
 
 struct Cmp{T} <: ScanExpr
-    op::UInt8
+    op::ComparisonOperator
     lhs::Col
     rhs::T
-    function Cmp(op::Integer, lhs::Col, rhs::T) where {T}
-        OP_EQ <= op <= OP_GE ||
-            throw(ArgumentError("unknown comparison operator code $op"))
+    function Cmp(op::ComparisonOperator, lhs::Col, rhs::T) where {T}
         rhs isa Col && _colcolerr()
-        return new{T}(UInt8(op), lhs, rhs)
+        return new{T}(op, lhs, rhs)
     end
 end
+function Cmp(op::Integer, lhs::Col, rhs)
+    0x01 <= op <= 0x06 || throw(ArgumentError("unknown comparison operator code $op"))
+    return Cmp(ComparisonOperator(op), lhs, rhs)
+end
 
+_comparisonoperator(::typeof(==)) = OP_EQ
+_comparisonoperator(::typeof(!=)) = OP_NE
+_comparisonoperator(::typeof(<)) = OP_LT
+_comparisonoperator(::typeof(<=)) = OP_LE
+_comparisonoperator(::typeof(>)) = OP_GT
+_comparisonoperator(::typeof(>=)) = OP_GE
+_comparisonoperator(op) = throw(ArgumentError(
+    "unsupported comparison function $(repr(op)); expected ==, !=, <, <=, >, or >=",
+))
 """
-    Tables.coleq(col, value)
-    Tables.colne(col, value)
-    Tables.collt(col, value)
-    Tables.colle(col, value)
-    Tables.colgt(col, value)
-    Tables.colge(col, value)
+    Tables.colcmp(op, col, value)
 
-Build a comparison predicate for a column and a literal value. These named
-constructors accept any literal type. `<`, `<=`, `>`, and `>=` provide shorthand
-for numeric, string, and character values. Equality uses `coleq` and `colne` so
-`Base.isequal` keeps its Boolean contract.
+Build a comparison predicate for a column and a literal value. `op` must be
+`==`, `!=`, `<`, `<=`, `>`, or `>=`. Ordered comparisons also support the
+shorthand `col(:x) < value` for numeric, string, and character values.
+
+Use `colcmp` for equality so `==` and `isequal` on expression objects keep
+their normal Boolean contracts.
 """
-coleq(c::Col, value) = Cmp(OP_EQ, c, value)
-colne(c::Col, value) = Cmp(OP_NE, c, value)
-collt(c::Col, value) = Cmp(OP_LT, c, value)
-colle(c::Col, value) = Cmp(OP_LE, c, value)
-colgt(c::Col, value) = Cmp(OP_GT, c, value)
-colge(c::Col, value) = Cmp(OP_GE, c, value)
+colcmp(op, c::Col, value) = Cmp(_comparisonoperator(op), c, value)
 
 struct In{T} <: ScanExpr
     lhs::Col
@@ -148,11 +151,12 @@ struct In{T} <: ScanExpr
 end
 
 """
-    Tables.in_(col, values)
+    Tables.colin(col, values)
 
-Membership predicate: `in_(col(:status), ("active", "trial"))`.
+Build a membership predicate: `colin(col(:status), ("active", "trial"))`.
+If the column value is `missing`, the predicate result is also `missing`.
 """
-in_(c::Col, values) = In(c, values)
+colin(c::Col, values) = In(c, values)
 
 struct IsNull <: ScanExpr
     lhs::Col
@@ -167,23 +171,29 @@ Use `!Tables.isnull(col)` to match values that are not `missing`.
 
 The `isnull` name is deliberate. Defining `Base.ismissing(::Col)` would
 specialize Base's broad fallback and invalidate unrelated precompiled code
-when Tables loads. Use `isnull` rather than `coleq(col(:x), missing)`, which
-follows SQL semantics and matches no row.
+when Tables loads. Use `isnull` rather than `colcmp(==, col(:x), missing)`,
+which follows SQL semantics and matches no row.
 """
 function isnull end
 isnull(c::Col) = IsNull(c, false)
 
-const STR_STARTSWITH, STR_ENDSWITH, STR_CONTAINS = 0x01, 0x02, 0x03
+@enum StringPredicate::UInt8 begin
+    STR_STARTSWITH = 0x01
+    STR_ENDSWITH = 0x02
+    STR_CONTAINS = 0x03
+end
 
 struct StrPred <: ScanExpr
-    kind::UInt8
+    kind::StringPredicate
     lhs::Col
     s::String
-    function StrPred(kind::Integer, lhs::Col, s::AbstractString)
-        STR_STARTSWITH <= kind <= STR_CONTAINS ||
-            throw(ArgumentError("unknown string predicate code $kind"))
-        return new(UInt8(kind), lhs, String(s))
+    function StrPred(kind::StringPredicate, lhs::Col, s::AbstractString)
+        return new(kind, lhs, String(s))
     end
+end
+function StrPred(kind::Integer, lhs::Col, s::AbstractString)
+    0x01 <= kind <= 0x03 || throw(ArgumentError("unknown string predicate code $kind"))
+    return StrPred(StringPredicate(kind), lhs, s)
 end
 
 struct AndExpr <: ScanExpr
@@ -201,29 +211,27 @@ struct AlwaysFalse <: ScanExpr end
 """
     Tables.OpNode(name, args)
 
-The expression algebra's growth channel: a named node with child values.
-Sources that recognize `name` may push it down; the generic executor rejects
-unknown names, so new operations deploy source-first without new node types.
+The expression algebra's growth channel. Every node has a symbolic `name` and
+plain-data arguments. A source can recognize and consume that name before
+generic resolution. An unconsumed `OpNode` is rejected by `Tables.resolve` and
+the generic executor.
 """
 struct OpNode <: ScanExpr
     name::Symbol
     args::Vector{Any}
 end
 
-for f in (:coleq, :colne, :collt, :colle, :colgt, :colge)
-    @eval $f(::Col, ::Col) = _colcolerr()
-end
 for T in (Number, AbstractString, AbstractChar)
     @eval begin
-        Base.:<(c::Col, v::$T) = collt(c, v)
-        Base.:<(v::$T, c::Col) = colgt(c, v)
-        Base.:<=(c::Col, v::$T) = colle(c, v)
-        Base.:<=(v::$T, c::Col) = colge(c, v)
+        Base.:<(c::Col, v::$T) = colcmp(<, c, v)
+        Base.:<(v::$T, c::Col) = colcmp(>, c, v)
+        Base.:<=(c::Col, v::$T) = colcmp(<=, c, v)
+        Base.:<=(v::$T, c::Col) = colcmp(>=, c, v)
     end
 end
 Base.:(==)(a::Col, b::Col) = a.ref == b.ref
 Base.isequal(a::Col, b::Col) = isequal(a.ref, b.ref)
-Base.hash(c::Col, h::UInt) = hash(c.ref, hash(:TablesCol, h))
+Base.hash(c::Col, h::UInt) = hash(c.ref, h + 0x6f38a7d1)
 Base.:<(::Col, ::Col) = _colcolerr()
 Base.:<=(::Col, ::Col) = _colcolerr()
 
@@ -255,7 +263,7 @@ _checkpredicate(e::ScanExpr) = e
 _checkpredicate(e::Col) =
     throw(ArgumentError("a bare column reference is not a predicate; compare it against a value"))
 _checkpredicate(x) =
-    throw(ArgumentError("filter must be a Tables.Scan expression (built from Tables.col), got $(typeof(x))"))
+    throw(ArgumentError("filter must be a Tables.ScanExpr built from Tables.col(...), got $(typeof(x))"))
 
 # --- the Scan value --------------------------------------------------------------
 
@@ -329,22 +337,16 @@ function Scan(s::Scan; select=s.select, filter=s.filter,
     return Scan(items, filter, lim, off, validate)
 end
 
-"""
-    isempty(scan::Tables.Scan)
-
-`true` when the scan requests nothing: no selection, no filter, no limit or
-offset. `Tables.scan` returns the table unchanged for an empty scan.
-"""
-Base.isempty(s::Scan) =
+_isidentity(s::Scan) =
     s.select === nothing && s.filter === nothing && s.limit === nothing && s.offset == 0
 
 
-# --- binding ---------------------------------------------------------------------
+# --- schema resolution -----------------------------------------------------------
 
 """
     Tables.BoundColumn
 
-One output column after `Tables.bind`: the source column index, the output
+One output column after `Tables.resolve`: the source column index, the output
 name (post-rename, uniqueness enforced), and the optional type override.
 """
 struct BoundColumn
@@ -357,8 +359,9 @@ end
     Tables.BoundScan
 
 A `Scan` resolved against a concrete schema: output columns in order, the
-(validated) filter with the source column indices it references, and the
-row bounds. Sources can use this after binding a raw `Scan`.
+filter with positional references normalized to source names, the source
+column indices it references, and the row bounds. Sources can use this after
+resolving a raw `Scan`.
 """
 struct BoundScan
     columns::Vector{BoundColumn}
@@ -366,37 +369,36 @@ struct BoundScan
     filtercols::Vector{Int}
     limit::Union{Nothing, Int}
     offset::Int
+    validate::Bool
 end
 
 _findcol(names, r::Symbol) = findfirst(==(r), names)
 _findcol(names, r::String) = findfirst(==(Symbol(r)), names)
 _findcol(names, r::Int) = 1 <= r <= length(names) ? r : nothing
+function _findcols(names, r::Regex)
+    return findall(nm -> occursin(r, String(nm)), names)
+end
+function _findcols(names, r)
+    i = _findcol(names, r)
+    return i === nothing ? Int[] : Int[i]
+end
 _refstr(r) = r isa Regex ? "r$(repr(r.pattern))" : repr(r)
 
 function _expand!(out::Vector{BoundColumn}, names, it::SelectItem, validate::Bool)
     r = it.ref
     if r isa All
         append!(out, BoundColumn(i, nm, it.type) for (i, nm) in enumerate(names))
-    elseif r isa Regex
-        found = false
-        for (i, nm) in enumerate(names)
-            if occursin(r, String(nm))
-                push!(out, BoundColumn(i, it.rename === nothing ? nm : it.rename, it.type))
-                found = true
-            end
-        end
-        validate && !found &&
-            throw(ArgumentError("select pattern $(_refstr(r)) matches no column"))
-        found && it.rename !== nothing && count(c -> c.name == it.rename, out) > 1 &&
-            throw(ArgumentError("pattern rename $(repr(it.rename)) applies to multiple columns"))
     else
-        i = _findcol(names, r)
-        if i === nothing
+        found = _findcols(names, r)
+        if isempty(found)
             validate && throw(ArgumentError("select reference $(_refstr(r)) matches no column " *
                                             "(pass validate=false to skip unmatched references)"))
             return
         end
-        push!(out, BoundColumn(i, it.rename === nothing ? names[i] : it.rename, it.type))
+        r isa Regex && it.rename !== nothing && length(found) > 1 &&
+            throw(ArgumentError("pattern rename $(repr(it.rename)) applies to multiple columns"))
+        append!(out, BoundColumn(i, it.rename === nothing ? names[i] : it.rename, it.type)
+                     for i in found)
     end
     return
 end
@@ -404,32 +406,45 @@ end
 _notrefs(x::Union{Tuple, AbstractVector}) = collect(Any, x)
 _notrefs(x) = Any[x]
 
-function _filterrefs!(refs::Vector{Int}, e::ScanExpr, names, validate::Bool)
-    if e isa Union{Cmp, In, IsNull, StrPred}
-        i = _findcol(names, e.lhs.ref)
+function _resolvefilter(e::ScanExpr, names, refs::Vector{Int}, validate::Bool)
+    if e isa Col
+        i = _findcol(names, e.ref)
         i === nothing && validate &&
-            throw(ArgumentError("filter references unknown column $(_refstr(e.lhs.ref))"))
-        i === nothing || (i in refs || push!(refs, i))
+            throw(ArgumentError("filter references unknown column $(_refstr(e.ref))"))
+        i === nothing && return e
+        i in refs || push!(refs, i)
+        return Col(names[i])
+    elseif e isa Cmp
+        return Cmp(e.op, _resolvefilter(e.lhs, names, refs, validate), e.rhs)
+    elseif e isa In
+        return In(_resolvefilter(e.lhs, names, refs, validate), e.values)
+    elseif e isa IsNull
+        return IsNull(_resolvefilter(e.lhs, names, refs, validate), e.negated)
+    elseif e isa StrPred
+        return StrPred(e.kind, _resolvefilter(e.lhs, names, refs, validate), e.s)
     elseif e isa AndExpr || e isa OrExpr
-        foreach(a -> _filterrefs!(refs, a, names, validate), e.args)
+        args = ScanExpr[_resolvefilter(a, names, refs, validate) for a in e.args]
+        return e isa AndExpr ? AndExpr(args) : OrExpr(args)
     elseif e isa NotExpr
-        _filterrefs!(refs, e.arg, names, validate)
+        return NotExpr(_resolvefilter(e.arg, names, refs, validate))
     elseif e isa OpNode
-        throw(ArgumentError("cannot bind extension node $(repr(e.name)): no generic evaluation; " *
-                            "only sources that recognize it may consume it"))
+        throw(ArgumentError("cannot resolve extension node $(repr(e.name)); " *
+                            "a source must consume it before calling Tables.resolve"))
     end
-    return refs
+    return e
 end
 
 """
-    Tables.bind(scan::Scan, names) -> BoundScan
+    Tables.resolve(scan::Scan, names) -> BoundScan
 
 Resolve a `Scan` against a source's column names (any iterable of `Symbol`s).
 Errors on unmatched references (under `validate`), mixed `Not`/positive
 selections, and duplicate output names. Regex references expand in file
-order; selection order defines output order.
+order; selection order defines output order. Positional filter references are
+replaced with source names so the resolved filter remains valid over a subset
+containing only its referenced columns.
 """
-function bind(scan::Scan, names)
+function resolve(scan::Scan, names)
     nms = collect(Symbol, names)
     cols = BoundColumn[]
     if scan.select === nothing
@@ -437,22 +452,11 @@ function bind(scan::Scan, names)
     elseif !isempty(scan.select) && scan.select[1].ref isa Not
         excluded = Set{Int}()
         for it in scan.select, r in _notrefs((it.ref::Not).ref)
-            if r isa Regex
-                found = false
-                for (i, nm) in enumerate(nms)
-                    if occursin(r, String(nm))
-                        push!(excluded, i)
-                        found = true
-                    end
-                end
-                scan.validate && !found &&
-                    throw(ArgumentError("Not pattern $(_refstr(r)) matches no column"))
-            else
-                i = _findcol(nms, r)
-                i === nothing && scan.validate &&
-                    throw(ArgumentError("Not reference $(_refstr(r)) matches no column"))
-                i === nothing || push!(excluded, i)
-            end
+            found = _findcols(nms, r)
+            scan.validate && isempty(found) && throw(ArgumentError(
+                "Not(...) $(r isa Regex ? "pattern" : "reference") $(_refstr(r)) matches no column",
+            ))
+            union!(excluded, found)
         end
         append!(cols, BoundColumn(i, nm, nothing) for (i, nm) in enumerate(nms) if !(i in excluded))
     else
@@ -465,8 +469,9 @@ function bind(scan::Scan, names)
         push!(seen, c.name)
     end
     refs = Int[]
-    scan.filter === nothing || _filterrefs!(refs, scan.filter, nms, scan.validate)
-    return BoundScan(cols, scan.filter, refs, scan.limit, scan.offset)
+    filter = scan.filter === nothing ? nothing :
+             _resolvefilter(scan.filter, nms, refs, scan.validate)
+    return BoundScan(cols, filter, refs, scan.limit, scan.offset, scan.validate)
 end
 
 # --- generic evaluation ------------------------------------------------------------
@@ -475,11 +480,9 @@ _getcol(cols, ref::Symbol) = getcolumn(cols, ref)
 _getcol(cols, ref::String) = getcolumn(cols, Symbol(ref))
 _getcol(cols, ref::Int) = getcolumn(cols, ref)
 
-# Resolve a filter leaf's column. Under `strict` an unknown reference is an
-# error; otherwise it resolves to `nothing` and the leaf evaluates as an
-# ALL-MISSING column — the schema-evolution semantics: a column this table
-# does not have reads as missing everywhere (`isnull` keeps every row, every
-# comparison excludes, and three-valued `&`/`|` compose from there).
+# Under `strict`, an unknown filter reference is an error. Otherwise, it
+# resolves to an all-missing column. `isnull` then keeps every row, comparisons
+# exclude every row, and Boolean expressions use three-valued logic.
 function _resolvecol(cols, ref, strict::Bool)
     i = _findcol(columnnames(cols), ref)
     i === nothing || return getcolumn(cols, i)
@@ -511,13 +514,13 @@ function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
     elseif e isa In
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
-        return _columnmap(x -> in(x, e.values), a, rowcount(cols))
+        return _columnmap(x -> ismissing(x) ? missing : in(x, e.values), a, rowcount(cols))
     elseif e isa IsNull
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing &&
             return e.negated ? falses(rowcount(cols)) : trues(rowcount(cols))
-        return e.negated ? _columnmap(x -> !Base.ismissing(x), a, rowcount(cols)) :
-                           _columnmap(Base.ismissing, a, rowcount(cols))
+        return e.negated ? _columnmap(x -> !ismissing(x), a, rowcount(cols)) :
+                           _columnmap(ismissing, a, rowcount(cols))
     elseif e isa StrPred
         a = _resolvecol(cols, e.lhs.ref, strict)
         a === nothing && return fill(missing, rowcount(cols))
@@ -525,7 +528,7 @@ function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
             e.kind == STR_ENDSWITH ? endswith :
             e.kind == STR_CONTAINS ? contains :
             throw(ArgumentError("unknown string predicate code $(e.kind)"))
-        return _columnmap(x -> Base.ismissing(x) ? missing : f(x, e.s), a, rowcount(cols))
+        return _columnmap(x -> ismissing(x) ? missing : f(x, e.s), a, rowcount(cols))
     elseif e isa AndExpr
         isempty(e.args) && return trues(rowcount(cols))
         return mapreduce(a -> _evalexpr(a, cols, strict), (x, y) -> x .& y, e.args)
@@ -542,16 +545,6 @@ function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
     throw(ArgumentError("cannot generically evaluate $(typeof(e))"))
 end
 
-"""
-    Tables.filtermask(scan_or_expr, table) -> AbstractVector{Bool}
-
-Evaluate a scan's filter over a table's columns: `mask[i]` is `true` iff row
-`i` qualifies (a `missing` predicate result excludes the row). Sources use
-this for their own pushdown implementations. The bare-expression form is
-strict about unknown column references; the `Scan` form follows the scan's
-`validate` — under `validate=false` an unmatched reference evaluates as an
-all-missing column.
-"""
 # The Bool-mask comprehension runs behind a FUNCTION BARRIER: `_evalexpr`
 # returns an abstractly-typed vector (its result type depends on the
 # expression tree), and `Bool[x === true for x in v]` over an abstract `v`
@@ -560,48 +553,119 @@ all-missing column.
 # barrier costs ONE dynamic dispatch per mask instead. The column kernels
 # inside `_evalexpr` specialize on the concrete container at their own call
 # boundary.
-_boolmask(v::AbstractVector) = Bool[x === true for x in v]
+@noinline _boolmask(v::AbstractVector) = Bool[x === true for x in v]
+"""
+    Tables.filtermask(scan_or_expr, table) -> AbstractVector{Bool}
+
+Evaluate a scan's filter over a table's columns: `mask[i]` is `true` iff row
+`i` qualifies (a `missing` predicate result excludes the row). Sources use
+this for their own pushdown implementations. The bare-expression form is
+strict about unknown column references. The `Scan` form follows the scan's
+`validate` setting. The `BoundScan` form uses its resolved filter and is safe
+to evaluate over a table containing only `filtercols`.
+"""
 filtermask(e::ScanExpr, table) = _boolmask(_evalexpr(_checkpredicate(e), columns(table)))
 filtermask(s::Scan, table) = s.filter === nothing ?
+    trues(rowcount(columns(table))) :
+    _boolmask(_evalexpr(s.filter, columns(table), s.validate))
+filtermask(s::BoundScan, table) = s.filter === nothing ?
     trues(rowcount(columns(table))) :
     _boolmask(_evalexpr(s.filter, columns(table), s.validate))
 
 _converted(::Nothing, c::AbstractVector) = c
 function _converted(::Type{T}, c::AbstractVector) where {T}
     eltype(c) <: Union{T, Missing} && return c
-    anymissing = any(Base.ismissing, c)
+    anymissing = any(ismissing, c)
     E = anymissing ? Union{T, Missing} : T
-    return E[Base.ismissing(x) ? missing : convert(T, x) for x in c]
+    out = allocatecolumn(E, length(c))
+    @inbounds for i in eachindex(c)
+        x = c[i]
+        out[i] = ismissing(x) ? missing : convert(T, x)
+    end
+    return out
 end
 
 _takecolumn(c::AbstractVector, idx) = c[idx]
 _takecolumn(c, idx) = [c[i] for i in idx]
 
+struct _ScanTable{T <: NamedTuple} <: AbstractColumns
+    columns::T
+    nrows::Int
+end
+columnnames(t::_ScanTable) = propertynames(getfield(t, :columns))
+getcolumn(t::_ScanTable, i::Int) = getfield(getfield(t, :columns), i)
+getcolumn(t::_ScanTable, name::Symbol) = getproperty(getfield(t, :columns), name)
+rowcount(t::_ScanTable) = getfield(t, :nrows)
+
+function _zerocolumnpredicate(e)
+    e === nothing && return true
+    e isa AlwaysTrue && return true
+    e isa AlwaysFalse && return false
+    e isa IsNull && return !e.negated
+    if e isa AndExpr
+        sawmissing = false
+        for arg in e.args
+            result = _zerocolumnpredicate(arg)
+            result === false && return false
+            result === missing && (sawmissing = true)
+        end
+        return sawmissing ? missing : true
+    elseif e isa OrExpr
+        sawmissing = false
+        for arg in e.args
+            result = _zerocolumnpredicate(arg)
+            result === true && return true
+            result === missing && (sawmissing = true)
+        end
+        return sawmissing ? missing : false
+    elseif e isa NotExpr
+        result = _zerocolumnpredicate(e.arg)
+        return result === missing ? missing : !result
+    elseif e isa OpNode
+        throw(ArgumentError("cannot generically evaluate extension node $(repr(e.name))"))
+    end
+    return missing
+end
+
+function _windowcount(n::Int, filterresult, offset::Int, limit::Union{Nothing, Int})
+    filterresult === true || return 0
+    skipped = min(offset, n)
+    available = n - skipped
+    return limit === nothing ? available : min(limit, available)
+end
+
 """
     Tables.scan(table, scan::Scan) -> table′
 
-Apply a `Scan` generically over ANY Tables.jl table: filter (SQL missing
-semantics: a predicate evaluating to `missing` excludes the row), then
-offset/limit, then projection, renames, and type overrides (elementwise
-`convert`). Returns the table unchanged when the scan is empty; otherwise a
-`NamedTuple` of columns. This is the reference semantics every pushdown
-must agree with, and the executor sources hand their residual to.
+Apply a `Scan` generically over any Tables.jl table: filter, then offset/limit,
+then projection, renames, and type overrides. A filter keeps only exact `true`;
+`missing` excludes the row. The input table is returned unchanged for an
+identity request. Other results are column tables. A zero-column result keeps
+its row count.
+
+This is the reference behavior every pushdown must preserve. A source can hand
+its unconsumed residual request to this function.
 """
 function scan(table, scan::Scan)
-    isempty(scan) && return table
+    _isidentity(scan) && return table
     cols = columns(table)
-    b = bind(scan, columnnames(cols))
-    if scan.filter !== nothing
-        keep = _boolmask(_evalexpr(scan.filter, cols, scan.validate))
+    b = resolve(scan, columnnames(cols))
+    nrows = rowcount(cols)
+    if isempty(columnnames(cols))
+        taken = _windowcount(nrows, _zerocolumnpredicate(b.filter), b.offset, b.limit)
+        return _ScanTable(NamedTuple(), taken)
+    elseif b.filter !== nothing
+        keep = filtermask(b, cols)
         idx = findall(keep)
     else
-        idx = 1:rowcount(cols)
+        idx = 1:nrows
     end
-    skipped = min(scan.offset, length(idx))
+    skipped = min(b.offset, length(idx))
     available = length(idx) - skipped
-    taken = scan.limit === nothing ? available : min(scan.limit, available)
+    taken = b.limit === nothing ? available : min(b.limit, available)
     idx = idx[(skipped + 1):(skipped + taken)]
     outnames = Tuple(c.name for c in b.columns)
+    isempty(outnames) && return _ScanTable(NamedTuple(), taken)
     outcols = Tuple(_converted(c.type, _takecolumn(getcolumn(cols, c.index), idx)) for c in b.columns)
     return NamedTuple{outnames}(outcols)
 end
@@ -609,8 +673,8 @@ end
 # --- display -----------------------------------------------------------------------
 
 function _exprstr(e::ScanExpr)
-    e isa Cmp && return "col($(repr(e.lhs.ref))) $(_OPNAMES[e.op]) $(repr(e.rhs))"
-    e isa In && return "in_(col($(repr(e.lhs.ref))), $(repr(e.values)))"
+    e isa Cmp && return "colcmp($(_OPNAMES[Int(e.op)]), col($(repr(e.lhs.ref))), $(repr(e.rhs)))"
+    e isa In && return "colin(col($(repr(e.lhs.ref))), $(repr(e.values)))"
     e isa IsNull && return (e.negated ? "!isnull(" : "isnull(") * "col($(repr(e.lhs.ref))))"
     e isa StrPred && return (e.kind == STR_STARTSWITH ? "startswith" :
                              e.kind == STR_ENDSWITH ? "endswith" : "contains") *
@@ -654,6 +718,6 @@ EXPLAIN affordance for pushdown debugging.
 """
 function describe(io::IO, scan::Scan, residual::Scan)
     println(io, "scan:     ", scan)
-    println(io, "residual: ", isempty(residual) ? "(empty — fully pushed down)" : residual)
+    println(io, "residual: ", _isidentity(residual) ? "(empty — fully pushed down)" : residual)
 end
 describe(scan::Scan, residual::Scan) = describe(stdout, scan, residual)

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -213,8 +213,11 @@ qualify, and how many. Plain data all the way down — see `Tables.apply`,
     predicate evaluates to exactly `true` (`missing` excludes, SQL-style).
     Filters see source column names, before renames.
   * `limit`/`offset`: applied to qualifying rows, after the filter.
-  * `validate`: error on select/filter references that match no column
-    (`false` silently drops unmatched names — the schema-evolution knob).
+  * `validate`: error on select/filter references that match no column.
+    `false` is the schema-evolution knob: unmatched SELECT references are
+    silently dropped, and an unmatched FILTER reference evaluates as an
+    all-missing column (`isnull(col(:gone))` keeps every row; comparisons
+    against it exclude, SQL-style).
 """
 struct Scan
     select::Union{Nothing, Vector{SelectItem}}
@@ -388,33 +391,54 @@ _getcol(cols, ref::Symbol) = getcolumn(cols, ref)
 _getcol(cols, ref::String) = getcolumn(cols, Symbol(ref))
 _getcol(cols, ref::Int) = getcolumn(cols, ref)
 
+# Resolve a filter leaf's column. Under `strict` an unknown reference is an
+# error; otherwise it resolves to `nothing` and the leaf evaluates as an
+# ALL-MISSING column — the schema-evolution semantics: a column this table
+# does not have reads as null everywhere (`isnull` keeps every row, every
+# comparison excludes, and three-valued `&`/`|` compose from there).
+function _resolvecol(cols, ref, strict::Bool)
+    i = _findcol(columnnames(cols), ref)
+    i === nothing || return getcolumn(cols, i)
+    strict && throw(ArgumentError("filter references unknown column $(_refstr(ref))"))
+    return nothing
+end
+
 # three-valued vectorized evaluation; the top level keeps rows where the
-# result is exactly `true` (SQL WHERE)
-function _evalexpr(e::ScanExpr, cols)
+# result is exactly `true` (SQL WHERE). Comparison literals are `Ref`-wrapped
+# so collection-valued rows compare WHOLE-VALUE per row — a bare vector
+# literal must never broadcast elementwise against the column (silent
+# row-zipping when the lengths happen to match, `DimensionMismatch` when
+# they don't).
+function _evalexpr(e::ScanExpr, cols, strict::Bool=true)
     if e isa Cmp
-        a = _getcol(cols, e.lhs.ref)
-        v = e.rhs
+        a = _resolvecol(cols, e.lhs.ref, strict)
+        a === nothing && return fill(missing, rowcount(cols))
+        v = Ref(e.rhs)
         return e.op == OP_EQ ? (a .== v) :
                e.op == OP_LT ? (a .< v) :
                e.op == OP_LE ? (a .<= v) :
                e.op == OP_GT ? (a .> v) : (a .>= v)
     elseif e isa In
-        a = _getcol(cols, e.lhs.ref)
+        a = _resolvecol(cols, e.lhs.ref, strict)
+        a === nothing && return fill(missing, rowcount(cols))
         return in.(a, Ref(e.values))
     elseif e isa IsNull
-        a = _getcol(cols, e.lhs.ref)
+        a = _resolvecol(cols, e.lhs.ref, strict)
+        a === nothing &&
+            return e.negated ? falses(rowcount(cols)) : trues(rowcount(cols))
         return e.negated ? .!ismissing.(a) : ismissing.(a)
     elseif e isa StrPred
-        a = _getcol(cols, e.lhs.ref)
+        a = _resolvecol(cols, e.lhs.ref, strict)
+        a === nothing && return fill(missing, rowcount(cols))
         f = e.kind == STR_STARTSWITH ? startswith :
             e.kind == STR_ENDSWITH ? endswith : contains
         return map(x -> ismissing(x) ? missing : f(x, e.s), a)
     elseif e isa AndExpr
-        return mapreduce(a -> _evalexpr(a, cols), (x, y) -> x .& y, e.args)
+        return mapreduce(a -> _evalexpr(a, cols, strict), (x, y) -> x .& y, e.args)
     elseif e isa OrExpr
-        return mapreduce(a -> _evalexpr(a, cols), (x, y) -> x .| y, e.args)
+        return mapreduce(a -> _evalexpr(a, cols, strict), (x, y) -> x .| y, e.args)
     elseif e isa NotExpr
-        return .!_evalexpr(e.arg, cols)
+        return .!_evalexpr(e.arg, cols, strict)
     elseif e isa AlwaysTrue
         return trues(rowcount(cols))
     elseif e isa AlwaysFalse
@@ -428,11 +452,15 @@ end
 
 Evaluate a scan's filter over a table's columns: `mask[i]` is `true` iff row
 `i` qualifies (a `missing` predicate result excludes the row). Sources use
-this for their own pushdown implementations.
+this for their own pushdown implementations. The bare-expression form is
+strict about unknown column references; the `Scan` form follows the scan's
+`validate` — under `validate=false` an unmatched reference evaluates as an
+all-missing column.
 """
 filtermask(e::ScanExpr, table) = Bool[x === true for x in _evalexpr(e, columns(table))]
 filtermask(s::Scan, table) = s.filter === nothing ?
-    trues(rowcount(columns(table))) : filtermask(s.filter, table)
+    trues(rowcount(columns(table))) :
+    Bool[x === true for x in _evalexpr(s.filter, columns(table), s.validate)]
 
 _converted(::Nothing, c::AbstractVector) = c
 function _converted(::Type{T}, c::AbstractVector) where {T}
@@ -456,7 +484,7 @@ function finish(table, scan::Scan)
     cols = columns(table)
     b = bind(scan, columnnames(cols))
     if scan.filter !== nothing
-        keep = Bool[x === true for x in _evalexpr(scan.filter, cols)]
+        keep = Bool[x === true for x in _evalexpr(scan.filter, cols, scan.validate)]
         idx = findall(keep)
     else
         idx = collect(1:rowcount(cols))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1080,3 +1080,4 @@ Tables.columnnames(::MockRow) = fieldnames(MockRow)
     expected_compact = "MockRow[(a = 1, b = 2, c = 3), (a = 4, b = 5, c = 6)]"
     @test sprint(show, tbl, context=:compact => true) == expected_compact
 end
+include("scan.jl")

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -180,10 +180,10 @@
         t, residual = T.apply(nt, T.Scan(limit = 2))
         @test t === nt && residual.limit == 2                          # fallback pushes nothing
         s = T.Scan(select = (:b, :a), filter = T.col(:a) >= 2, limit = 1)
-        @test isequal(T.read(nt, s), T.finish(nt, s))                  # protocol equivalence
+        @test isequal(T.scan(nt, s), T.finish(nt, s))                  # protocol equivalence
         # works through any Tables.jl source, e.g. a row iterator
         rows = Tables.rowtable(nt)
-        out = T.read(rows, s)
+        out = T.scan(rows, s)
         @test out.b == ["yy"] && out.a == [2]
         @test T.filtermask(s, nt) == [false, true, true, true, false]
     end

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -103,18 +103,18 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test isempty(b.filtercols)
     end
 
-    @testset "finish: filter semantics (SQL missing), limit/offset, projection" begin
-        out = T.finish(nt, T.Scan(filter = T.col(:a) > 1))
+    @testset "scan: filter semantics (SQL missing), limit/offset, projection" begin
+        out = T.scan(nt, T.Scan(filter = T.col(:a) > 1))
         @test out.a == [2, 3, 4]                                      # missing row EXCLUDED
-        out = T.finish(nt, T.Scan(filter = T.isnull(T.col(:a))))
+        out = T.scan(nt, T.Scan(filter = T.isnull(T.col(:a))))
         @test length(out.a) == 1 && ismissing(out.a[1])
-        out = T.finish(nt, T.Scan(filter = !T.isnull(T.col(:a))))
+        out = T.scan(nt, T.Scan(filter = !T.isnull(T.col(:a))))
         @test out.a == [1, 2, 3, 4]
-        out = T.finish(nt, T.Scan(filter = T.colne(T.col(:a), 1)))
+        out = T.scan(nt, T.Scan(filter = T.colne(T.col(:a), 1)))
         @test out.a == [2, 3, 4]                                      # colne never matches missing
-        out = T.finish(nt, T.Scan(filter = T.in_(T.col(:b), ("x", "w"))))
+        out = T.scan(nt, T.Scan(filter = T.in_(T.col(:b), ("x", "w"))))
         @test out.b == ["x", "x", "w"]
-        out = T.finish(nt, T.Scan(filter = startswith(T.col(:b), "z") | endswith(T.col(:b), "y")))
+        out = T.scan(nt, T.Scan(filter = startswith(T.col(:b), "z") | endswith(T.col(:b), "y")))
         @test out.b == ["yy", "zzz"]
         missingvals = (a = Union{Int, Missing}[1, missing, 3],
                        b = Union{String, Missing}["x", missing, "z"])
@@ -139,55 +139,55 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
               [true, false, false, false]
         @test_throws ArgumentError T.Cmp(0xff, T.col(:a), 1)
         @test_throws ArgumentError T.StrPred(0xff, T.col(:b), "x")
-        out = T.finish(nt, T.Scan(limit = 2, offset = 1))
+        out = T.scan(nt, T.Scan(limit = 2, offset = 1))
         @test isequal(out.a, [2, 3])
-        out = T.finish(nt, T.Scan(filter = T.col(:c) > 2.0, limit = 2))
+        out = T.scan(nt, T.Scan(filter = T.col(:c) > 2.0, limit = 2))
         @test out.c == [2.5, 3.5]
-        out = T.finish(nt, T.Scan(offset = 10))
+        out = T.scan(nt, T.Scan(offset = 10))
         @test isempty(out.a)
-        out = T.finish(nt, T.Scan(offset = typemax(Int)))
+        out = T.scan(nt, T.Scan(offset = typemax(Int)))
         @test isempty(out.a)
-        out = T.finish(nt, T.Scan(offset = 1, limit = typemax(Int)))
+        out = T.scan(nt, T.Scan(offset = 1, limit = typemax(Int)))
         @test isequal(out.a, [2, 3, 4, missing])
         # projection order, rename, type override
-        out = T.finish(nt, T.Scan(select = (:c => Float32 => :cf, 1)))
+        out = T.scan(nt, T.Scan(select = (:c => Float32 => :cf, 1)))
         @test keys(out) == (:cf, :a)
         @test out.cf isa Vector{Float32}
         # type override preserves missing
-        out = T.finish(nt, T.Scan(select = (:a => Float64,)))
+        out = T.scan(nt, T.Scan(select = (:a => Float64,)))
         @test isequal(out.a, [1.0, 2.0, 3.0, 4.0, missing])
         @test eltype(out.a) == Union{Float64, Missing}
         converted = Union{Float64, Missing}[1.0, missing]
         @test T._converted(Float64, converted) === converted
-        @test_throws InexactError T.finish((a = [1.5],), T.Scan(select = (:a => Int,)))
+        @test_throws InexactError T.scan((a = [1.5],), T.Scan(select = (:a => Int,)))
         indexonly = IndexOnlyTable(IndexOnlyColumn([10, 20, 30, 40]))
-        @test T.finish(indexonly, T.Scan(select = :a, offset = 1, limit = 2)).a == [20, 30]
+        @test T.scan(indexonly, T.Scan(select = :a, offset = 1, limit = 2)).a == [20, 30]
         # empty residual = identity
-        @test T.finish(nt, T.Scan()) === nt
+        @test T.scan(nt, T.Scan()) === nt
     end
 
-    @testset "finish: validate=false filters treat unmatched refs as all-missing" begin
+    @testset "scan: validate=false filters treat unmatched refs as all-missing" begin
         nt2 = (a = [1, 2, 3], b = ["x", "y", "z"])
         # strict (default): unknown filter refs error, matching bind
-        @test_throws ArgumentError T.finish(nt2, T.Scan(filter = T.col(:gone) > 1))
+        @test_throws ArgumentError T.scan(nt2, T.Scan(filter = T.col(:gone) > 1))
         @test_throws ArgumentError T.filtermask(T.col(:gone) > 1, nt2)
         # lenient: comparisons/membership/strings against the absent column
         # evaluate to missing → rows excluded, SQL-style
         for f in (T.col(:gone) > 1, T.in_(T.col(:gone), (1, 2)),
                   startswith(T.col(:gone), "x"))
-            out = T.finish(nt2, T.Scan(filter = f, validate = false))
+            out = T.scan(nt2, T.Scan(filter = f, validate = false))
             @test isempty(out.a)
         end
         # the absent column reads as missing: isnull keeps all, !isnull keeps none
-        out = T.finish(nt2, T.Scan(filter = T.isnull(T.col(:gone)), validate = false))
+        out = T.scan(nt2, T.Scan(filter = T.isnull(T.col(:gone)), validate = false))
         @test out.a == [1, 2, 3]
-        out = T.finish(nt2, T.Scan(filter = !T.isnull(T.col(:gone)), validate = false))
+        out = T.scan(nt2, T.Scan(filter = !T.isnull(T.col(:gone)), validate = false))
         @test isempty(out.a)
         # three-valued composition with a matched predicate
-        out = T.finish(nt2, T.Scan(filter = (T.col(:gone) > 1) | (T.col(:a) >= 3),
+        out = T.scan(nt2, T.Scan(filter = (T.col(:gone) > 1) | (T.col(:a) >= 3),
                                    validate = false))
         @test out.a == [3]
-        out = T.finish(nt2, T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) >= 1),
+        out = T.scan(nt2, T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) >= 1),
                                    validate = false))
         @test isempty(out.a)
         # the Scan form of filtermask follows validate; bind still omits the
@@ -199,38 +199,44 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test b.filtercols == [1]
     end
 
-    @testset "finish: collection-valued rows compare whole-value per row" begin
+    @testset "scan: collection-valued rows compare whole-value per row" begin
         lists = (l = [[1, 2], [3], [1, 2]], n = [10, 20, 30])
         # equality against a vector literal is per-row whole-value equality —
         # never an elementwise broadcast into the rows (which zips silently
         # when lengths happen to match and throws DimensionMismatch when not)
-        out = T.finish(lists, T.Scan(filter = T.coleq(T.col(:l), [1, 2])))
+        out = T.scan(lists, T.Scan(filter = T.coleq(T.col(:l), [1, 2])))
         @test out.n == [10, 30]
-        out = T.finish(lists, T.Scan(filter = T.colne(T.col(:l), [1, 2])))
+        out = T.scan(lists, T.Scan(filter = T.colne(T.col(:l), [1, 2])))
         @test out.n == [20]
         @test T.filtermask(T.in_(T.col(:l), ([[3]], [[1, 2]])), lists) ==
               [false, false, false]
         @test T.filtermask(T.in_(T.col(:l), ([3],)), lists) == [false, true, false]
         # a 2-row column against a 2-element literal must still be whole-value
         two = (l = [[1, 2], [5, 6]], n = [1, 2])
-        out = T.finish(two, T.Scan(filter = T.coleq(T.col(:l), [5, 6])))
+        out = T.scan(two, T.Scan(filter = T.coleq(T.col(:l), [5, 6])))
         @test out.n == [2]
         # missing rows keep SQL semantics through the Ref-wrapped comparison
         lm = (l = Union{Missing, Vector{Int}}[[1], missing, [2]], n = [1, 2, 3])
-        out = T.finish(lm, T.Scan(filter = T.coleq(T.col(:l), [2])))
+        out = T.scan(lm, T.Scan(filter = T.coleq(T.col(:l), [2])))
         @test out.n == [3]
     end
 
-    @testset "apply/scan protocol" begin
-        t, residual = T.apply(nt, T.Scan(limit = 2))
-        @test t === nt && residual.limit == 2                          # fallback pushes nothing
+    @testset "generic executor + residual construction" begin
         s = T.Scan(select = (:b, :a), filter = T.col(:a) >= 2, limit = 1)
-        @test isequal(T.scan(nt, s), T.finish(nt, s))                  # protocol equivalence
+        out = T.scan(nt, s)
+        @test out.b == ["yy"] && out.a == [2]
         # works through any Tables.jl source, e.g. a row iterator
         rows = Tables.rowtable(nt)
         out = T.scan(rows, s)
         @test out.b == ["yy"] && out.a == [2]
         @test T.filtermask(s, nt) == [false, true, true, true, false]
+        # a source that pushed select/limit down hands the filter to Tables.scan
+        residual = T.Scan(s; select = nothing, limit = nothing, offset = 0)
+        @test residual.select === nothing && residual.limit === nothing && residual.filter === s.filter
+        pushed = (b = nt.b, a = nt.a)                # what the source materialized (projection done)
+        @test isequal(T.scan(pushed, residual).a, [2, 3, 4])   # filter applied generically
+        @test isempty(T.Scan(s; select = nothing, filter = nothing, limit = nothing))
+        @test T.Scan(s; select = (:c,)).select == T.Scan(select = (:c,)).select
     end
 
     @testset "display" begin
@@ -241,7 +247,7 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test occursin("filter = true", sprint(show, T.Scan(filter = T.AndExpr(T.ScanExpr[]))))
         @test occursin("filter = false", sprint(show, T.Scan(filter = T.OrExpr(T.ScanExpr[]))))
         io = IOBuffer()
-        T.describe(io, s, T.EMPTYSCAN)
+        T.describe(io, s, T.Scan())
         @test occursin("fully pushed down", String(take!(io)))
     end
 

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -121,6 +121,61 @@
         @test T.finish(nt, T.Scan()) === nt
     end
 
+    @testset "finish: validate=false filters treat unmatched refs as all-missing" begin
+        nt2 = (a = [1, 2, 3], b = ["x", "y", "z"])
+        # strict (default): unknown filter refs error, matching bind
+        @test_throws ArgumentError T.finish(nt2, T.Scan(filter = T.col(:gone) > 1))
+        @test_throws ArgumentError T.filtermask(T.col(:gone) > 1, nt2)
+        # lenient: comparisons/membership/strings against the absent column
+        # evaluate to missing → rows excluded, SQL-style
+        for f in (T.col(:gone) > 1, T.in_(T.col(:gone), (1, 2)),
+                  startswith(T.col(:gone), "x"))
+            out = T.finish(nt2, T.Scan(filter = f, validate = false))
+            @test isempty(out.a)
+        end
+        # the absent column reads as null: isnull keeps all, !isnull keeps none
+        out = T.finish(nt2, T.Scan(filter = T.isnull(T.col(:gone)), validate = false))
+        @test out.a == [1, 2, 3]
+        out = T.finish(nt2, T.Scan(filter = !T.isnull(T.col(:gone)), validate = false))
+        @test isempty(out.a)
+        # three-valued composition with a matched predicate
+        out = T.finish(nt2, T.Scan(filter = (T.col(:gone) > 1) | (T.col(:a) >= 3),
+                                   validate = false))
+        @test out.a == [3]
+        out = T.finish(nt2, T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) >= 1),
+                                   validate = false))
+        @test isempty(out.a)
+        # the Scan form of filtermask follows validate; bind still omits the
+        # unmatched ref from filtercols
+        @test T.filtermask(T.Scan(filter = T.isnull(T.col(:gone)), validate = false),
+                           nt2) == [true, true, true]
+        b = T.bind(T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) > 1),
+                          validate = false), (:a, :b))
+        @test b.filtercols == [1]
+    end
+
+    @testset "finish: collection-valued rows compare whole-value per row" begin
+        lists = (l = [[1, 2], [3], [1, 2]], n = [10, 20, 30])
+        # equality against a vector literal is per-row whole-value equality —
+        # never an elementwise broadcast into the rows (which zips silently
+        # when lengths happen to match and throws DimensionMismatch when not)
+        out = T.finish(lists, T.Scan(filter = T.col(:l) == [1, 2]))
+        @test out.n == [10, 30]
+        out = T.finish(lists, T.Scan(filter = T.col(:l) != [1, 2]))
+        @test out.n == [20]
+        @test T.filtermask(T.in_(T.col(:l), ([[3]], [[1, 2]])), lists) ==
+              [false, false, false]
+        @test T.filtermask(T.in_(T.col(:l), ([3],)), lists) == [false, true, false]
+        # a 2-row column against a 2-element literal must still be whole-value
+        two = (l = [[1, 2], [5, 6]], n = [1, 2])
+        out = T.finish(two, T.Scan(filter = T.col(:l) == [5, 6]))
+        @test out.n == [2]
+        # missing rows keep SQL semantics through the Ref-wrapped comparison
+        lm = (l = Union{Missing, Vector{Int}}[[1], missing, [2]], n = [1, 2, 3])
+        out = T.finish(lm, T.Scan(filter = T.col(:l) == [2]))
+        @test out.n == [3]
+    end
+
     @testset "apply/read protocol" begin
         t, residual = T.apply(nt, T.Scan(limit = 2))
         @test t === nt && residual.limit == 2                          # fallback pushes nothing

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -4,8 +4,8 @@ end
 Base.length(c::IndexOnlyColumn) = length(c.data)
 Base.getindex(c::IndexOnlyColumn, i::Int) = c.data[i]
 
-struct IndexOnlyTable <: Tables.AbstractColumns
-    a::IndexOnlyColumn{Int}
+struct IndexOnlyTable{T} <: Tables.AbstractColumns
+    a::IndexOnlyColumn{T}
 end
 Tables.columnnames(::IndexOnlyTable) = (:a,)
 Tables.getcolumn(t::IndexOnlyTable, ::Int) = getfield(t, :a)
@@ -38,7 +38,13 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test_throws ArgumentError T.Scan(select = T.Not(1.5))
         @test_throws ArgumentError T.Scan(limit = -1)
         @test_throws ArgumentError T.Scan(offset = -1)
+        @test_throws ArgumentError T.Scan(T.Scan(); limit = -1)
+        @test_throws ArgumentError T.Scan(T.Scan(); offset = -1)
+        @test_throws ArgumentError T.Scan(nothing, nothing, -1, 0, true)
+        @test T.Scan(T.Scan(); limit = Int16(2)).limit == 2
         @test_throws ArgumentError T.Scan(filter = T.col(:a))         # bare column
+        @test_throws ArgumentError T.Scan(filter = !T.col(:a))
+        @test_throws ArgumentError T.Scan(filter = T.col(:a) & (T.col(:b) > 1))
         @test_throws ArgumentError T.Scan(filter = (x -> true))       # closures rejected
     end
 
@@ -62,6 +68,8 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test c == T.col(:a)
         @test c != T.col(:b)
         @test_throws ArgumentError T.coleq(T.col(:a), T.col(:b))      # col-to-col filter
+        @test_throws ArgumentError T.Cmp(T.OP_EQ, T.col(:a), T.col(:b))
+        @test_throws ArgumentError T.In(T.col(:a), T.col(:b))
         e = (c > 1) & (c < 5) & T.in_(T.col(:b), ("x", "w"))
         @test e isa T.AndExpr && length(e.args) == 3                  # flattened
         o = (c > 1) | (c < 0) | T.isnull(c)
@@ -128,6 +136,7 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
               [false, false, false]
         @test T.filtermask(T.Cmp(T.OP_NE, T.col(:a), 1), missingvals) ==
               [false, false, true]
+        @test_throws ArgumentError T.filtermask(!T.col(:a), missingvals)
         @test T.filtermask(T.AndExpr(T.ScanExpr[]), missingvals) == [true, true, true]
         @test T.filtermask(T.OrExpr(T.ScanExpr[]), missingvals) == [false, false, false]
         # the final function barrier keeps only exact `true` (SQL WHERE)
@@ -162,6 +171,13 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test_throws InexactError T.scan((a = [1.5],), T.Scan(select = (:a => Int,)))
         indexonly = IndexOnlyTable(IndexOnlyColumn([10, 20, 30, 40]))
         @test T.scan(indexonly, T.Scan(select = :a, offset = 1, limit = 2)).a == [20, 30]
+        @test T.filtermask(T.col(:a) > 20, indexonly) == [false, false, true, true]
+        @test T.filtermask(T.in_(T.col(:a), (10, 40)), indexonly) ==
+              [true, false, false, true]
+        indexmissing = IndexOnlyTable(IndexOnlyColumn(Union{Int, Missing}[10, missing, 30]))
+        @test T.filtermask(T.isnull(T.col(:a)), indexmissing) == [false, true, false]
+        indexstrings = IndexOnlyTable(IndexOnlyColumn(["ab", "bc", "ax"]))
+        @test T.filtermask(startswith(T.col(:a), "a"), indexstrings) == [true, false, true]
         # empty residual = identity
         @test T.scan(nt, T.Scan()) === nt
     end
@@ -215,7 +231,7 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         two = (l = [[1, 2], [5, 6]], n = [1, 2])
         out = T.scan(two, T.Scan(filter = T.coleq(T.col(:l), [5, 6])))
         @test out.n == [2]
-        # missing rows keep SQL semantics through the Ref-wrapped comparison
+        # missing rows keep SQL semantics through whole-value comparison
         lm = (l = Union{Missing, Vector{Int}}[[1], missing, [2]], n = [1, 2, 3])
         out = T.scan(lm, T.Scan(filter = T.coleq(T.col(:l), [2])))
         @test out.n == [3]

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -38,7 +38,11 @@ Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
         @test s.select[5] == T.SelectItem(4, nothing, nothing)
         @test s.select[6].ref isa Regex
         @test T.Scan(select = :a).select == [T.SelectItem(:a, nothing, nothing)]
+        @test T.Scan().select == [T.SelectItem(T.All(), nothing, nothing)]
+        @test isempty(T.Scan(select = ()).select)
+        @test_throws ArgumentError T.Scan(select = nothing)
         @test T._isidentity(T.Scan())
+        @test T._isidentity(T.Scan(select = T.All()))
         @test !T._isidentity(T.Scan(limit = 5))
         @test !T._isidentity(T.Scan(offset = 1))
         @test_throws ArgumentError T.Scan(select = (:a => 1.5,))
@@ -48,7 +52,7 @@ Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
         @test_throws ArgumentError T.Scan(offset = -1)
         @test_throws ArgumentError T.Scan(T.Scan(); limit = -1)
         @test_throws ArgumentError T.Scan(T.Scan(); offset = -1)
-        @test_throws ArgumentError T.Scan(nothing, nothing, -1, 0, true)
+        @test_throws ArgumentError T.Scan(T.Scan().select, nothing, -1, 0, true)
         @test T.Scan(T.Scan(); limit = Int16(2)).limit == 2
         @test_throws ArgumentError T.Scan(filter = T.col(:a))         # bare column
         @test_throws ArgumentError T.Scan(filter = !T.col(:a))
@@ -266,11 +270,11 @@ Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
         @test out.b == ["yy"] && out.a == [2]
         @test T.filtermask(s, nt) == [false, true, true, true, false]
         # a source that pushed select/limit down hands the filter to Tables.scan
-        residual = T.Scan(s; select = nothing, limit = nothing, offset = 0)
-        @test residual.select === nothing && residual.limit === nothing && residual.filter === s.filter
+        residual = T.Scan(s; select = T.All(), limit = nothing, offset = 0)
+        @test T._isallselection(residual.select) && residual.limit === nothing && residual.filter === s.filter
         pushed = (b = nt.b, a = nt.a)                # what the source materialized (projection done)
         @test isequal(T.scan(pushed, residual).a, [2, 3, 4])   # filter applied generically
-        @test T._isidentity(T.Scan(s; select = nothing, filter = nothing, limit = nothing))
+        @test T._isidentity(T.Scan(s; select = T.All(), filter = nothing, limit = nothing))
         @test T.Scan(s; select = (:c,)).select == T.Scan(select = (:c,)).select
     end
 
@@ -310,6 +314,8 @@ Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
         @test occursin("isnull", sprint(show, T.Scan(filter = T.isnull(T.col(:x)))))
         @test occursin("filter = true", sprint(show, T.Scan(filter = T.AndExpr(T.ScanExpr[]))))
         @test occursin("filter = false", sprint(show, T.Scan(filter = T.OrExpr(T.ScanExpr[]))))
+        @test sprint(show, T.Scan()) == "Tables.Scan()"
+        @test sprint(show, T.Scan(select = ())) == "Tables.Scan(select = ())"
         io = IOBuffer()
         T.describe(io, s, T.Scan())
         @test occursin("fully pushed down", String(take!(io)))

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -53,17 +53,18 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test T.colgt(c, 1).op == T.OP_GT
         @test T.colge(c, 1).op == T.OP_GE
         @test T.coleq(c, :ready).rhs == :ready                         # general literal form
-        @test T.ismissing !== Base.ismissing
+        @test T.isnull(c) == T.IsNull(T.Col(:a), false)
         @test Base.ismissing(c) === false
+        @test which(Base.ismissing, (typeof(c),)) === which(Base.ismissing, (Any,))
         @test Base.isequal(c, c) === true
         @test Base.isequal(c, 1) === false
-        @test !T.ismissing(c) == T.IsMissing(T.Col(:a), true)
+        @test !T.isnull(c) == T.IsNull(T.Col(:a), true)
         @test c == T.col(:a)
         @test c != T.col(:b)
         @test_throws ArgumentError T.coleq(T.col(:a), T.col(:b))      # col-to-col filter
         e = (c > 1) & (c < 5) & T.in_(T.col(:b), ("x", "w"))
         @test e isa T.AndExpr && length(e.args) == 3                  # flattened
-        o = (c > 1) | (c < 0) | T.ismissing(c)
+        o = (c > 1) | (c < 0) | T.isnull(c)
         @test o isa T.OrExpr && length(o.args) == 3
         @test T.in_(T.col(:b), ["x"]) isa T.In
         @test startswith(T.col(:b), "z") isa T.StrPred
@@ -81,7 +82,7 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test_throws ArgumentError T.bind(T.Scan(select = (:a, T.All())), names)
         b = T.bind(T.Scan(select = T.Not((r"^x_", :b))), names)
         @test [c.index for c in b.columns] == [1, 3]
-        b = T.bind(T.Scan(filter = (T.col(:a) > 1) & T.ismissing(T.col(:c))), names)
+        b = T.bind(T.Scan(filter = (T.col(:a) > 1) & T.isnull(T.col(:c))), names)
         @test sort(b.filtercols) == [1, 3]
         @test_throws ArgumentError T.bind(T.Scan(select = :nope), names)
         @test_throws ArgumentError T.bind(T.Scan(select = 6), names)
@@ -105,9 +106,9 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
     @testset "finish: filter semantics (SQL missing), limit/offset, projection" begin
         out = T.finish(nt, T.Scan(filter = T.col(:a) > 1))
         @test out.a == [2, 3, 4]                                      # missing row EXCLUDED
-        out = T.finish(nt, T.Scan(filter = T.ismissing(T.col(:a))))
+        out = T.finish(nt, T.Scan(filter = T.isnull(T.col(:a))))
         @test length(out.a) == 1 && ismissing(out.a[1])
-        out = T.finish(nt, T.Scan(filter = !T.ismissing(T.col(:a))))
+        out = T.finish(nt, T.Scan(filter = !T.isnull(T.col(:a))))
         @test out.a == [1, 2, 3, 4]
         out = T.finish(nt, T.Scan(filter = T.colne(T.col(:a), 1)))
         @test out.a == [2, 3, 4]                                      # colne never matches missing
@@ -170,10 +171,10 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
             out = T.finish(nt2, T.Scan(filter = f, validate = false))
             @test isempty(out.a)
         end
-        # the absent column reads as missing: ismissing keeps all, !ismissing keeps none
-        out = T.finish(nt2, T.Scan(filter = T.ismissing(T.col(:gone)), validate = false))
+        # the absent column reads as missing: isnull keeps all, !isnull keeps none
+        out = T.finish(nt2, T.Scan(filter = T.isnull(T.col(:gone)), validate = false))
         @test out.a == [1, 2, 3]
-        out = T.finish(nt2, T.Scan(filter = !T.ismissing(T.col(:gone)), validate = false))
+        out = T.finish(nt2, T.Scan(filter = !T.isnull(T.col(:gone)), validate = false))
         @test isempty(out.a)
         # three-valued composition with a matched predicate
         out = T.finish(nt2, T.Scan(filter = (T.col(:gone) > 1) | (T.col(:a) >= 3),
@@ -184,7 +185,7 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test isempty(out.a)
         # the Scan form of filtermask follows validate; bind still omits the
         # unmatched ref from filtercols
-        @test T.filtermask(T.Scan(filter = T.ismissing(T.col(:gone)), validate = false),
+        @test T.filtermask(T.Scan(filter = T.isnull(T.col(:gone)), validate = false),
                            nt2) == [true, true, true]
         b = T.bind(T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) > 1),
                           validate = false), (:a, :b))
@@ -226,10 +227,10 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
     end
 
     @testset "display" begin
-        s = T.Scan(select = (:a => Int64 => :z, T.All()), filter = !T.ismissing(T.col(:a)), limit = 3)
+        s = T.Scan(select = (:a => Int64 => :z, T.All()), filter = !T.isnull(T.col(:a)), limit = 3)
         str = sprint(show, s)
         @test occursin("select =", str) && occursin("limit = 3", str)
-        @test occursin("ismissing", sprint(show, T.Scan(filter = T.ismissing(T.col(:x)))))
+        @test occursin("isnull", sprint(show, T.Scan(filter = T.isnull(T.col(:x)))))
         @test occursin("filter = true", sprint(show, T.Scan(filter = T.AndExpr(T.ScanExpr[]))))
         @test occursin("filter = false", sprint(show, T.Scan(filter = T.OrExpr(T.ScanExpr[]))))
         io = IOBuffer()

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -321,4 +321,32 @@ Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
         @test occursin("fully pushed down", String(take!(io)))
     end
 
+    @testset "All arguments, Union{} override, residual composition" begin
+        # DataAPI.All(cols...) with arguments must not silently select everything
+        @test_throws ArgumentError T.Scan(select = T.All(:a))
+        @test_throws ArgumentError T.Scan(select = (T.All(:a, :b),))
+
+        # a Union{} column still honors the requested override type
+        empty = T.scan((u = Union{}[],), T.Scan(select = (:u => Float64,)))
+        @test T.columntable(empty).u isa Vector{Float64}
+
+        # residual composition: stripping a consumed axis reproduces the
+        # reference result, in execution order (filter, then row bounds,
+        # then projection)
+        source = (a = collect(1:6), b = collect(10.0:10.0:60.0))
+        request = T.Scan(select = (:b => :value,), filter = T.col(:a) > 2,
+                         limit = 2, offset = 1)
+        reference = T.columntable(T.scan(source, request))
+        @test reference == (value = [40.0, 50.0],)
+        # source consumed the filter
+        mask = T.filtermask(request, source)
+        filtered = (a = source.a[mask], b = source.b[mask])
+        residual = T.Scan(request; filter = nothing)
+        @test T.columntable(T.scan(filtered, residual)) == reference
+        # source consumed the filter and the row bounds
+        bounded = (a = filtered.a[2:3], b = filtered.b[2:3])
+        residual2 = T.Scan(request; filter = nothing, limit = nothing, offset = 0)
+        @test T.columntable(T.scan(bounded, residual2)) == reference
+    end
+
 end

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -1,0 +1,124 @@
+@testset "scan.jl" begin
+
+    T = Tables
+    nt = (a = [1, 2, 3, 4, missing],
+          b = ["x", "yy", "zzz", "x", "w"],
+          c = [1.5, 2.5, 3.5, 4.5, 5.5],
+          x_one = [10, 20, 30, 40, 50],
+          x_two = [-1, -2, -3, -4, -5])
+
+    @testset "construction & lowering" begin
+        s = T.Scan(select = (:a, "b" => :bee, :c => Float32, :a => Int64 => :a2, 4, r"^x_"))
+        @test length(s.select) == 6
+        @test s.select[1] == T.SelectItem(:a, nothing, nothing)
+        @test s.select[2] == T.SelectItem("b", nothing, :bee)
+        @test s.select[3] == T.SelectItem(:c, Float32, nothing)
+        @test s.select[4] == T.SelectItem(:a, Int64, :a2)
+        @test s.select[5] == T.SelectItem(4, nothing, nothing)
+        @test s.select[6].ref isa Regex
+        @test T.Scan(select = :a).select == [T.SelectItem(:a, nothing, nothing)]
+        @test isempty(T.Scan())
+        @test !isempty(T.Scan(limit = 5))
+        @test !isempty(T.Scan(offset = 1))
+        @test_throws ArgumentError T.Scan(select = (:a => 1.5,))
+        @test_throws ArgumentError T.Scan(select = (T.Not(:a), :b))   # mixed Not/positive
+        @test_throws ArgumentError T.Scan(limit = -1)
+        @test_throws ArgumentError T.Scan(offset = -1)
+        @test_throws ArgumentError T.Scan(filter = T.col(:a))         # bare column
+        @test_throws ArgumentError T.Scan(filter = (x -> true))       # closures rejected
+    end
+
+    @testset "expression algebra" begin
+        c = T.col(:a)
+        @test (c > 1) isa T.Cmp{Int}
+        @test (1 > c).op == T.OP_LT                                   # reversed comparison flips
+        @test (c != 1) isa T.NotExpr
+        @test !(c != 1) isa T.Cmp{Int}                                # double negation unwraps
+        @test !T.isnull(c) == T.IsNull(T.Col(:a), true)
+        @test_throws ArgumentError T.col(:a) == T.col(:b)             # col-to-col
+        e = (c > 1) & (c < 5) & T.in_(T.col(:b), ("x", "w"))
+        @test e isa T.AndExpr && length(e.args) == 3                  # flattened
+        o = (c > 1) | (c < 0) | T.isnull(c)
+        @test o isa T.OrExpr && length(o.args) == 3
+        @test T.in(T.col(:b), ["x"]) isa T.In                         # Base.in sugar
+        @test startswith(T.col(:b), "z") isa T.StrPred
+    end
+
+    @testset "bind" begin
+        names = [:a, :b, :c, :x_one, :x_two]
+        b = T.bind(T.Scan(), names)
+        @test [c.index for c in b.columns] == 1:5
+        b = T.bind(T.Scan(select = (r"^x_", :a => :first)), names)
+        @test [(c.index, c.name) for c in b.columns] == [(4, :x_one), (5, :x_two), (1, :first)]
+        b = T.bind(T.Scan(select = T.Not((r"^x_", :b))), names)
+        @test [c.index for c in b.columns] == [1, 3]
+        b = T.bind(T.Scan(filter = (T.col(:a) > 1) & T.isnull(T.col(:c))), names)
+        @test sort(b.filtercols) == [1, 3]
+        @test_throws ArgumentError T.bind(T.Scan(select = :nope), names)
+        @test_throws ArgumentError T.bind(T.Scan(select = 6), names)
+        @test_throws ArgumentError T.bind(T.Scan(select = r"^nope"), names)
+        @test_throws ArgumentError T.bind(T.Scan(select = (:a, :b => :a)), names)   # dup output
+        @test_throws ArgumentError T.bind(T.Scan(select = r"^x_" => :same), names)  # multi rename
+        @test_throws ArgumentError T.bind(T.Scan(filter = T.col(:nope) > 1), names)
+        @test_throws ArgumentError T.bind(T.Scan(filter = T.OpNode(:custom, Any[])), names)
+        # validate=false silently drops unmatched, keeps the rest
+        b = T.bind(T.Scan(select = (:nope, :a), validate = false), names)
+        @test [c.index for c in b.columns] == [1]
+        b = T.bind(T.Scan(filter = T.col(:nope) > 1, validate = false), names)
+        @test isempty(b.filtercols)
+    end
+
+    @testset "finish: filter semantics (SQL missing), limit/offset, projection" begin
+        out = T.finish(nt, T.Scan(filter = T.col(:a) > 1))
+        @test out.a == [2, 3, 4]                                      # missing row EXCLUDED
+        out = T.finish(nt, T.Scan(filter = T.isnull(T.col(:a))))
+        @test length(out.a) == 1 && ismissing(out.a[1])
+        out = T.finish(nt, T.Scan(filter = !T.isnull(T.col(:a))))
+        @test out.a == [1, 2, 3, 4]
+        out = T.finish(nt, T.Scan(filter = (T.col(:a) != 1)))
+        @test out.a == [2, 3, 4]                                      # != never matches missing
+        out = T.finish(nt, T.Scan(filter = T.in_(T.col(:b), ("x", "w"))))
+        @test out.b == ["x", "x", "w"]
+        out = T.finish(nt, T.Scan(filter = startswith(T.col(:b), "z") | endswith(T.col(:b), "y")))
+        @test out.b == ["yy", "zzz"]
+        out = T.finish(nt, T.Scan(limit = 2, offset = 1))
+        @test isequal(out.a, [2, 3])
+        out = T.finish(nt, T.Scan(filter = T.col(:c) > 2.0, limit = 2))
+        @test out.c == [2.5, 3.5]
+        out = T.finish(nt, T.Scan(offset = 10))
+        @test isempty(out.a)
+        # projection order, rename, type override
+        out = T.finish(nt, T.Scan(select = (:c => Float32 => :cf, 1)))
+        @test keys(out) == (:cf, :a)
+        @test out.cf isa Vector{Float32}
+        # type override preserves missing
+        out = T.finish(nt, T.Scan(select = (:a => Float64,)))
+        @test isequal(out.a, [1.0, 2.0, 3.0, 4.0, missing])
+        @test eltype(out.a) == Union{Float64, Missing}
+        # empty residual = identity
+        @test T.finish(nt, T.Scan()) === nt
+    end
+
+    @testset "apply/read protocol" begin
+        t, residual = T.apply(nt, T.Scan(limit = 2))
+        @test t === nt && residual.limit == 2                          # fallback pushes nothing
+        s = T.Scan(select = (:b, :a), filter = T.col(:a) >= 2, limit = 1)
+        @test isequal(T.read(nt, s), T.finish(nt, s))                  # protocol equivalence
+        # works through any Tables.jl source, e.g. a row iterator
+        rows = Tables.rowtable(nt)
+        out = T.read(rows, s)
+        @test out.b == ["yy"] && out.a == [2]
+        @test T.filtermask(s, nt) == [false, true, true, true, false]
+    end
+
+    @testset "display" begin
+        s = T.Scan(select = (:a => Int64 => :z, T.All()), filter = !T.isnull(T.col(:a)), limit = 3)
+        str = sprint(show, s)
+        @test occursin("select =", str) && occursin("limit = 3", str)
+        @test occursin("isnull", sprint(show, T.Scan(filter = T.isnull(T.col(:x)))))
+        io = IOBuffer()
+        T.describe(io, s, T.EMPTYSCAN)
+        @test occursin("fully pushed down", String(take!(io)))
+    end
+
+end

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -1,3 +1,16 @@
+struct IndexOnlyColumn{T}
+    data::Vector{T}
+end
+Base.length(c::IndexOnlyColumn) = length(c.data)
+Base.getindex(c::IndexOnlyColumn, i::Int) = c.data[i]
+
+struct IndexOnlyTable <: Tables.AbstractColumns
+    a::IndexOnlyColumn{Int}
+end
+Tables.columnnames(::IndexOnlyTable) = (:a,)
+Tables.getcolumn(t::IndexOnlyTable, ::Int) = getfield(t, :a)
+Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
+
 @testset "scan.jl" begin
 
     T = Tables
@@ -22,6 +35,7 @@
         @test !isempty(T.Scan(offset = 1))
         @test_throws ArgumentError T.Scan(select = (:a => 1.5,))
         @test_throws ArgumentError T.Scan(select = (T.Not(:a), :b))   # mixed Not/positive
+        @test_throws ArgumentError T.Scan(select = T.Not(1.5))
         @test_throws ArgumentError T.Scan(limit = -1)
         @test_throws ArgumentError T.Scan(offset = -1)
         @test_throws ArgumentError T.Scan(filter = T.col(:a))         # bare column
@@ -32,15 +46,26 @@
         c = T.col(:a)
         @test (c > 1) isa T.Cmp{Int}
         @test (1 > c).op == T.OP_LT                                   # reversed comparison flips
-        @test (c != 1) isa T.NotExpr
-        @test !(c != 1) isa T.Cmp{Int}                                # double negation unwraps
-        @test !T.isnull(c) == T.IsNull(T.Col(:a), true)
-        @test_throws ArgumentError T.col(:a) == T.col(:b)             # col-to-col
+        @test T.coleq(c, 1) == T.Cmp(T.OP_EQ, T.Col(:a), 1)
+        @test T.colne(c, 1).op == T.OP_NE
+        @test T.collt(c, 1).op == T.OP_LT
+        @test T.colle(c, 1).op == T.OP_LE
+        @test T.colgt(c, 1).op == T.OP_GT
+        @test T.colge(c, 1).op == T.OP_GE
+        @test T.coleq(c, :ready).rhs == :ready                         # general literal form
+        @test T.ismissing !== Base.ismissing
+        @test Base.ismissing(c) === false
+        @test Base.isequal(c, c) === true
+        @test Base.isequal(c, 1) === false
+        @test !T.ismissing(c) == T.IsMissing(T.Col(:a), true)
+        @test c == T.col(:a)
+        @test c != T.col(:b)
+        @test_throws ArgumentError T.coleq(T.col(:a), T.col(:b))      # col-to-col filter
         e = (c > 1) & (c < 5) & T.in_(T.col(:b), ("x", "w"))
         @test e isa T.AndExpr && length(e.args) == 3                  # flattened
-        o = (c > 1) | (c < 0) | T.isnull(c)
+        o = (c > 1) | (c < 0) | T.ismissing(c)
         @test o isa T.OrExpr && length(o.args) == 3
-        @test T.in(T.col(:b), ["x"]) isa T.In                         # Base.in sugar
+        @test T.in_(T.col(:b), ["x"]) isa T.In
         @test startswith(T.col(:b), "z") isa T.StrPred
     end
 
@@ -56,7 +81,7 @@
         @test_throws ArgumentError T.bind(T.Scan(select = (:a, T.All())), names)
         b = T.bind(T.Scan(select = T.Not((r"^x_", :b))), names)
         @test [c.index for c in b.columns] == [1, 3]
-        b = T.bind(T.Scan(filter = (T.col(:a) > 1) & T.isnull(T.col(:c))), names)
+        b = T.bind(T.Scan(filter = (T.col(:a) > 1) & T.ismissing(T.col(:c))), names)
         @test sort(b.filtercols) == [1, 3]
         @test_throws ArgumentError T.bind(T.Scan(select = :nope), names)
         @test_throws ArgumentError T.bind(T.Scan(select = 6), names)
@@ -80,12 +105,12 @@
     @testset "finish: filter semantics (SQL missing), limit/offset, projection" begin
         out = T.finish(nt, T.Scan(filter = T.col(:a) > 1))
         @test out.a == [2, 3, 4]                                      # missing row EXCLUDED
-        out = T.finish(nt, T.Scan(filter = T.isnull(T.col(:a))))
+        out = T.finish(nt, T.Scan(filter = T.ismissing(T.col(:a))))
         @test length(out.a) == 1 && ismissing(out.a[1])
-        out = T.finish(nt, T.Scan(filter = !T.isnull(T.col(:a))))
+        out = T.finish(nt, T.Scan(filter = !T.ismissing(T.col(:a))))
         @test out.a == [1, 2, 3, 4]
-        out = T.finish(nt, T.Scan(filter = (T.col(:a) != 1)))
-        @test out.a == [2, 3, 4]                                      # != never matches missing
+        out = T.finish(nt, T.Scan(filter = T.colne(T.col(:a), 1)))
+        @test out.a == [2, 3, 4]                                      # colne never matches missing
         out = T.finish(nt, T.Scan(filter = T.in_(T.col(:b), ("x", "w"))))
         @test out.b == ["x", "x", "w"]
         out = T.finish(nt, T.Scan(filter = startswith(T.col(:b), "z") | endswith(T.col(:b), "y")))
@@ -100,12 +125,22 @@
               [true, false, false]
         @test T.filtermask(!T.in_(T.col(:a), (1, missing)), missingvals) ==
               [false, false, false]
+        @test T.filtermask(T.Cmp(T.OP_NE, T.col(:a), 1), missingvals) ==
+              [false, false, true]
+        @test T.filtermask(T.AndExpr(T.ScanExpr[]), missingvals) == [true, true, true]
+        @test T.filtermask(T.OrExpr(T.ScanExpr[]), missingvals) == [false, false, false]
+        @test_throws ArgumentError T.Cmp(0xff, T.col(:a), 1)
+        @test_throws ArgumentError T.StrPred(0xff, T.col(:b), "x")
         out = T.finish(nt, T.Scan(limit = 2, offset = 1))
         @test isequal(out.a, [2, 3])
         out = T.finish(nt, T.Scan(filter = T.col(:c) > 2.0, limit = 2))
         @test out.c == [2.5, 3.5]
         out = T.finish(nt, T.Scan(offset = 10))
         @test isempty(out.a)
+        out = T.finish(nt, T.Scan(offset = typemax(Int)))
+        @test isempty(out.a)
+        out = T.finish(nt, T.Scan(offset = 1, limit = typemax(Int)))
+        @test isequal(out.a, [2, 3, 4, missing])
         # projection order, rename, type override
         out = T.finish(nt, T.Scan(select = (:c => Float32 => :cf, 1)))
         @test keys(out) == (:cf, :a)
@@ -117,6 +152,8 @@
         converted = Union{Float64, Missing}[1.0, missing]
         @test T._converted(Float64, converted) === converted
         @test_throws InexactError T.finish((a = [1.5],), T.Scan(select = (:a => Int,)))
+        indexonly = IndexOnlyTable(IndexOnlyColumn([10, 20, 30, 40]))
+        @test T.finish(indexonly, T.Scan(select = :a, offset = 1, limit = 2)).a == [20, 30]
         # empty residual = identity
         @test T.finish(nt, T.Scan()) === nt
     end
@@ -133,10 +170,10 @@
             out = T.finish(nt2, T.Scan(filter = f, validate = false))
             @test isempty(out.a)
         end
-        # the absent column reads as null: isnull keeps all, !isnull keeps none
-        out = T.finish(nt2, T.Scan(filter = T.isnull(T.col(:gone)), validate = false))
+        # the absent column reads as missing: ismissing keeps all, !ismissing keeps none
+        out = T.finish(nt2, T.Scan(filter = T.ismissing(T.col(:gone)), validate = false))
         @test out.a == [1, 2, 3]
-        out = T.finish(nt2, T.Scan(filter = !T.isnull(T.col(:gone)), validate = false))
+        out = T.finish(nt2, T.Scan(filter = !T.ismissing(T.col(:gone)), validate = false))
         @test isempty(out.a)
         # three-valued composition with a matched predicate
         out = T.finish(nt2, T.Scan(filter = (T.col(:gone) > 1) | (T.col(:a) >= 3),
@@ -147,7 +184,7 @@
         @test isempty(out.a)
         # the Scan form of filtermask follows validate; bind still omits the
         # unmatched ref from filtercols
-        @test T.filtermask(T.Scan(filter = T.isnull(T.col(:gone)), validate = false),
+        @test T.filtermask(T.Scan(filter = T.ismissing(T.col(:gone)), validate = false),
                            nt2) == [true, true, true]
         b = T.bind(T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) > 1),
                           validate = false), (:a, :b))
@@ -159,24 +196,24 @@
         # equality against a vector literal is per-row whole-value equality —
         # never an elementwise broadcast into the rows (which zips silently
         # when lengths happen to match and throws DimensionMismatch when not)
-        out = T.finish(lists, T.Scan(filter = T.col(:l) == [1, 2]))
+        out = T.finish(lists, T.Scan(filter = T.coleq(T.col(:l), [1, 2])))
         @test out.n == [10, 30]
-        out = T.finish(lists, T.Scan(filter = T.col(:l) != [1, 2]))
+        out = T.finish(lists, T.Scan(filter = T.colne(T.col(:l), [1, 2])))
         @test out.n == [20]
         @test T.filtermask(T.in_(T.col(:l), ([[3]], [[1, 2]])), lists) ==
               [false, false, false]
         @test T.filtermask(T.in_(T.col(:l), ([3],)), lists) == [false, true, false]
         # a 2-row column against a 2-element literal must still be whole-value
         two = (l = [[1, 2], [5, 6]], n = [1, 2])
-        out = T.finish(two, T.Scan(filter = T.col(:l) == [5, 6]))
+        out = T.finish(two, T.Scan(filter = T.coleq(T.col(:l), [5, 6])))
         @test out.n == [2]
         # missing rows keep SQL semantics through the Ref-wrapped comparison
         lm = (l = Union{Missing, Vector{Int}}[[1], missing, [2]], n = [1, 2, 3])
-        out = T.finish(lm, T.Scan(filter = T.col(:l) == [2]))
+        out = T.finish(lm, T.Scan(filter = T.coleq(T.col(:l), [2])))
         @test out.n == [3]
     end
 
-    @testset "apply/read protocol" begin
+    @testset "apply/scan protocol" begin
         t, residual = T.apply(nt, T.Scan(limit = 2))
         @test t === nt && residual.limit == 2                          # fallback pushes nothing
         s = T.Scan(select = (:b, :a), filter = T.col(:a) >= 2, limit = 1)
@@ -189,10 +226,12 @@
     end
 
     @testset "display" begin
-        s = T.Scan(select = (:a => Int64 => :z, T.All()), filter = !T.isnull(T.col(:a)), limit = 3)
+        s = T.Scan(select = (:a => Int64 => :z, T.All()), filter = !T.ismissing(T.col(:a)), limit = 3)
         str = sprint(show, s)
         @test occursin("select =", str) && occursin("limit = 3", str)
-        @test occursin("isnull", sprint(show, T.Scan(filter = T.isnull(T.col(:x)))))
+        @test occursin("ismissing", sprint(show, T.Scan(filter = T.ismissing(T.col(:x)))))
+        @test occursin("filter = true", sprint(show, T.Scan(filter = T.AndExpr(T.ScanExpr[]))))
+        @test occursin("filter = false", sprint(show, T.Scan(filter = T.OrExpr(T.ScanExpr[]))))
         io = IOBuffer()
         T.describe(io, s, T.EMPTYSCAN)
         @test occursin("fully pushed down", String(take!(io)))

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -50,6 +50,10 @@
         @test [c.index for c in b.columns] == 1:5
         b = T.bind(T.Scan(select = (r"^x_", :a => :first)), names)
         @test [(c.index, c.name) for c in b.columns] == [(4, :x_one), (5, :x_two), (1, :first)]
+        b = T.bind(T.Scan(select = (:a => :first, T.All())), names)
+        @test [(c.index, c.name) for c in b.columns] ==
+              [(1, :first), (1, :a), (2, :b), (3, :c), (4, :x_one), (5, :x_two)]
+        @test_throws ArgumentError T.bind(T.Scan(select = (:a, T.All())), names)
         b = T.bind(T.Scan(select = T.Not((r"^x_", :b))), names)
         @test [c.index for c in b.columns] == [1, 3]
         b = T.bind(T.Scan(filter = (T.col(:a) > 1) & T.isnull(T.col(:c))), names)
@@ -57,6 +61,7 @@
         @test_throws ArgumentError T.bind(T.Scan(select = :nope), names)
         @test_throws ArgumentError T.bind(T.Scan(select = 6), names)
         @test_throws ArgumentError T.bind(T.Scan(select = r"^nope"), names)
+        @test_throws ArgumentError T.bind(T.Scan(select = T.Not(r"^nope")), names)
         @test_throws ArgumentError T.bind(T.Scan(select = (:a, :b => :a)), names)   # dup output
         @test_throws ArgumentError T.bind(T.Scan(select = r"^x_" => :same), names)  # multi rename
         @test_throws ArgumentError T.bind(T.Scan(filter = T.col(:nope) > 1), names)
@@ -64,6 +69,8 @@
         # validate=false silently drops unmatched, keeps the rest
         b = T.bind(T.Scan(select = (:nope, :a), validate = false), names)
         @test [c.index for c in b.columns] == [1]
+        b = T.bind(T.Scan(select = T.Not((r"^nope", :b)), validate = false), names)
+        @test [c.index for c in b.columns] == [1, 3, 4, 5]
         b = T.bind(T.Scan(filter = T.col(:nope) > 1, validate = false), names)
         @test isempty(b.filtercols)
     end

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -69,6 +69,8 @@
         # validate=false silently drops unmatched, keeps the rest
         b = T.bind(T.Scan(select = (:nope, :a), validate = false), names)
         @test [c.index for c in b.columns] == [1]
+        b = T.bind(T.Scan(select = (9, :a), validate = false), names)
+        @test [c.index for c in b.columns] == [1]
         b = T.bind(T.Scan(select = T.Not((r"^nope", :b)), validate = false), names)
         @test [c.index for c in b.columns] == [1, 3, 4, 5]
         b = T.bind(T.Scan(filter = T.col(:nope) > 1, validate = false), names)
@@ -88,6 +90,16 @@
         @test out.b == ["x", "x", "w"]
         out = T.finish(nt, T.Scan(filter = startswith(T.col(:b), "z") | endswith(T.col(:b), "y")))
         @test out.b == ["yy", "zzz"]
+        missingvals = (a = Union{Int, Missing}[1, missing, 3],
+                       b = Union{String, Missing}["x", missing, "z"])
+        @test T.filtermask(T.in_(T.col(:a), (1, missing)), missingvals) ==
+              [true, false, false]
+        @test T.filtermask(T.in_(T.col(:a), (2, missing)), missingvals) ==
+              [false, false, false]
+        @test T.filtermask(startswith(T.col(:b), "x"), missingvals) ==
+              [true, false, false]
+        @test T.filtermask(!T.in_(T.col(:a), (1, missing)), missingvals) ==
+              [false, false, false]
         out = T.finish(nt, T.Scan(limit = 2, offset = 1))
         @test isequal(out.a, [2, 3])
         out = T.finish(nt, T.Scan(filter = T.col(:c) > 2.0, limit = 2))
@@ -102,6 +114,9 @@
         out = T.finish(nt, T.Scan(select = (:a => Float64,)))
         @test isequal(out.a, [1.0, 2.0, 3.0, 4.0, missing])
         @test eltype(out.a) == Union{Float64, Missing}
+        converted = Union{Float64, Missing}[1.0, missing]
+        @test T._converted(Float64, converted) === converted
+        @test_throws InexactError T.finish((a = [1.5],), T.Scan(select = (:a => Int,)))
         # empty residual = identity
         @test T.finish(nt, T.Scan()) === nt
     end

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -130,6 +130,13 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
               [false, false, true]
         @test T.filtermask(T.AndExpr(T.ScanExpr[]), missingvals) == [true, true, true]
         @test T.filtermask(T.OrExpr(T.ScanExpr[]), missingvals) == [false, false, false]
+        # the final function barrier keeps only exact `true` (SQL WHERE)
+        @test T._boolmask(BitVector([true, false])) == [true, false]
+        @test T._boolmask(Bool[false, true]) == [false, true]
+        @test T._boolmask(Union{Bool, Missing}[true, missing, false]) ==
+              [true, false, false]
+        @test T._boolmask(Any[true, 1, missing, nothing]) ==
+              [true, false, false, false]
         @test_throws ArgumentError T.Cmp(0xff, T.col(:a), 1)
         @test_throws ArgumentError T.StrPred(0xff, T.col(:b), "x")
         out = T.finish(nt, T.Scan(limit = 2, offset = 1))

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -11,6 +11,14 @@ Tables.columnnames(::IndexOnlyTable) = (:a,)
 Tables.getcolumn(t::IndexOnlyTable, ::Int) = getfield(t, :a)
 Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
 
+struct ZeroColumnTable <: Tables.AbstractColumns
+    nrows::Int
+end
+Tables.columnnames(::ZeroColumnTable) = ()
+Tables.getcolumn(::ZeroColumnTable, i::Int) = throw(BoundsError((), i))
+Tables.getcolumn(::ZeroColumnTable, name::Symbol) = throw(ArgumentError("unknown column $name"))
+Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
+
 @testset "scan.jl" begin
 
     T = Tables
@@ -30,9 +38,9 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test s.select[5] == T.SelectItem(4, nothing, nothing)
         @test s.select[6].ref isa Regex
         @test T.Scan(select = :a).select == [T.SelectItem(:a, nothing, nothing)]
-        @test isempty(T.Scan())
-        @test !isempty(T.Scan(limit = 5))
-        @test !isempty(T.Scan(offset = 1))
+        @test T._isidentity(T.Scan())
+        @test !T._isidentity(T.Scan(limit = 5))
+        @test !T._isidentity(T.Scan(offset = 1))
         @test_throws ArgumentError T.Scan(select = (:a => 1.5,))
         @test_throws ArgumentError T.Scan(select = (T.Not(:a), :b))   # mixed Not/positive
         @test_throws ArgumentError T.Scan(select = T.Not(1.5))
@@ -52,13 +60,14 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         c = T.col(:a)
         @test (c > 1) isa T.Cmp{Int}
         @test (1 > c).op == T.OP_LT                                   # reversed comparison flips
-        @test T.coleq(c, 1) == T.Cmp(T.OP_EQ, T.Col(:a), 1)
-        @test T.colne(c, 1).op == T.OP_NE
-        @test T.collt(c, 1).op == T.OP_LT
-        @test T.colle(c, 1).op == T.OP_LE
-        @test T.colgt(c, 1).op == T.OP_GT
-        @test T.colge(c, 1).op == T.OP_GE
-        @test T.coleq(c, :ready).rhs == :ready                         # general literal form
+        @test T.colcmp(==, c, 1) == T.Cmp(T.OP_EQ, T.Col(:a), 1)
+        @test T.colcmp(!=, c, 1).op == T.OP_NE
+        @test T.colcmp(<, c, 1).op == T.OP_LT
+        @test T.colcmp(<=, c, 1).op == T.OP_LE
+        @test T.colcmp(>, c, 1).op == T.OP_GT
+        @test T.colcmp(>=, c, 1).op == T.OP_GE
+        @test T.colcmp(==, c, :ready).rhs == :ready                    # general literal form
+        @test T.colcmp(==, c, 1).op isa T.ComparisonOperator
         @test T.isnull(c) == T.IsNull(T.Col(:a), false)
         @test Base.ismissing(c) === false
         @test which(Base.ismissing, (typeof(c),)) === which(Base.ismissing, (Any,))
@@ -67,48 +76,56 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test !T.isnull(c) == T.IsNull(T.Col(:a), true)
         @test c == T.col(:a)
         @test c != T.col(:b)
-        @test_throws ArgumentError T.coleq(T.col(:a), T.col(:b))      # col-to-col filter
+        @test_throws ArgumentError T.colcmp(==, T.col(:a), T.col(:b)) # col-to-col filter
+        @test_throws ArgumentError T.colcmp(isless, c, 1)
         @test_throws ArgumentError T.Cmp(T.OP_EQ, T.col(:a), T.col(:b))
         @test_throws ArgumentError T.In(T.col(:a), T.col(:b))
-        e = (c > 1) & (c < 5) & T.in_(T.col(:b), ("x", "w"))
+        e = (c > 1) & (c < 5) & T.colin(T.col(:b), ("x", "w"))
         @test e isa T.AndExpr && length(e.args) == 3                  # flattened
         o = (c > 1) | (c < 0) | T.isnull(c)
         @test o isa T.OrExpr && length(o.args) == 3
-        @test T.in_(T.col(:b), ["x"]) isa T.In
+        @test T.colin(T.col(:b), ["x"]) isa T.In
         @test startswith(T.col(:b), "z") isa T.StrPred
     end
 
-    @testset "bind" begin
+    @testset "resolve" begin
         names = [:a, :b, :c, :x_one, :x_two]
-        b = T.bind(T.Scan(), names)
+        @test T.All === DataAPI.All
+        b = T.resolve(T.Scan(), names)
         @test [c.index for c in b.columns] == 1:5
-        b = T.bind(T.Scan(select = (r"^x_", :a => :first)), names)
+        b = T.resolve(T.Scan(select = (r"^x_", :a => :first)), names)
         @test [(c.index, c.name) for c in b.columns] == [(4, :x_one), (5, :x_two), (1, :first)]
-        b = T.bind(T.Scan(select = (:a => :first, T.All())), names)
+        b = T.resolve(T.Scan(select = (:a => :first, T.All())), names)
         @test [(c.index, c.name) for c in b.columns] ==
               [(1, :first), (1, :a), (2, :b), (3, :c), (4, :x_one), (5, :x_two)]
-        @test_throws ArgumentError T.bind(T.Scan(select = (:a, T.All())), names)
-        b = T.bind(T.Scan(select = T.Not((r"^x_", :b))), names)
+        @test_throws ArgumentError T.resolve(T.Scan(select = (:a, T.All())), names)
+        b = T.resolve(T.Scan(select = T.Not((r"^x_", :b))), names)
         @test [c.index for c in b.columns] == [1, 3]
-        b = T.bind(T.Scan(filter = (T.col(:a) > 1) & T.isnull(T.col(:c))), names)
+        b = T.resolve(T.Scan(filter = (T.col(:a) > 1) & T.isnull(T.col(:c))), names)
         @test sort(b.filtercols) == [1, 3]
-        @test_throws ArgumentError T.bind(T.Scan(select = :nope), names)
-        @test_throws ArgumentError T.bind(T.Scan(select = 6), names)
-        @test_throws ArgumentError T.bind(T.Scan(select = r"^nope"), names)
-        @test_throws ArgumentError T.bind(T.Scan(select = T.Not(r"^nope")), names)
-        @test_throws ArgumentError T.bind(T.Scan(select = (:a, :b => :a)), names)   # dup output
-        @test_throws ArgumentError T.bind(T.Scan(select = r"^x_" => :same), names)  # multi rename
-        @test_throws ArgumentError T.bind(T.Scan(filter = T.col(:nope) > 1), names)
-        @test_throws ArgumentError T.bind(T.Scan(filter = T.OpNode(:custom, Any[])), names)
+        positional = T.resolve(T.Scan(filter = T.col(3) > 1), names)
+        @test positional.filter.lhs.ref === :c
+        @test T.filtermask(positional, (c = [1, 2, 3],)) == [false, true, true]
+        @test_throws ArgumentError T.resolve(T.Scan(select = :nope), names)
+        @test_throws ArgumentError T.resolve(T.Scan(select = 6), names)
+        @test_throws ArgumentError T.resolve(T.Scan(select = r"^nope"), names)
+        @test_throws ArgumentError T.resolve(T.Scan(select = T.Not(r"^nope")), names)
+        @test_throws ArgumentError T.resolve(T.Scan(select = (:a, :b => :a)), names)   # dup output
+        @test_throws ArgumentError T.resolve(T.Scan(select = r"^x_" => :same), names)  # multi rename
+        @test_throws ArgumentError T.resolve(T.Scan(filter = T.col(:nope) > 1), names)
+        @test_throws ArgumentError T.resolve(
+            T.Scan(filter = T.OpNode(:custom, Any[T.col(2), 1])), names,
+        )
         # validate=false silently drops unmatched, keeps the rest
-        b = T.bind(T.Scan(select = (:nope, :a), validate = false), names)
+        b = T.resolve(T.Scan(select = (:nope, :a), validate = false), names)
         @test [c.index for c in b.columns] == [1]
-        b = T.bind(T.Scan(select = (9, :a), validate = false), names)
+        b = T.resolve(T.Scan(select = (9, :a), validate = false), names)
         @test [c.index for c in b.columns] == [1]
-        b = T.bind(T.Scan(select = T.Not((r"^nope", :b)), validate = false), names)
+        b = T.resolve(T.Scan(select = T.Not((r"^nope", :b)), validate = false), names)
         @test [c.index for c in b.columns] == [1, 3, 4, 5]
-        b = T.bind(T.Scan(filter = T.col(:nope) > 1, validate = false), names)
+        b = T.resolve(T.Scan(filter = T.col(:nope) > 1, validate = false), names)
         @test isempty(b.filtercols)
+        @test T.filtermask(b, (a = [1, 2],)) == [false, false]
     end
 
     @testset "scan: filter semantics (SQL missing), limit/offset, projection" begin
@@ -118,21 +135,23 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test length(out.a) == 1 && ismissing(out.a[1])
         out = T.scan(nt, T.Scan(filter = !T.isnull(T.col(:a))))
         @test out.a == [1, 2, 3, 4]
-        out = T.scan(nt, T.Scan(filter = T.colne(T.col(:a), 1)))
-        @test out.a == [2, 3, 4]                                      # colne never matches missing
-        out = T.scan(nt, T.Scan(filter = T.in_(T.col(:b), ("x", "w"))))
+        out = T.scan(nt, T.Scan(filter = T.colcmp(!=, T.col(:a), 1)))
+        @test out.a == [2, 3, 4]                                      # != never matches missing
+        out = T.scan(nt, T.Scan(filter = T.colin(T.col(:b), ("x", "w"))))
         @test out.b == ["x", "x", "w"]
         out = T.scan(nt, T.Scan(filter = startswith(T.col(:b), "z") | endswith(T.col(:b), "y")))
         @test out.b == ["yy", "zzz"]
         missingvals = (a = Union{Int, Missing}[1, missing, 3],
                        b = Union{String, Missing}["x", missing, "z"])
-        @test T.filtermask(T.in_(T.col(:a), (1, missing)), missingvals) ==
+        @test T.filtermask(T.colin(T.col(:a), (1, missing)), missingvals) ==
               [true, false, false]
-        @test T.filtermask(T.in_(T.col(:a), (2, missing)), missingvals) ==
+        @test T.filtermask(T.colin(T.col(:a), (2, missing)), missingvals) ==
+              [false, false, false]
+        @test T.filtermask(T.colin(T.col(:a), Set([missing])), missingvals) ==
               [false, false, false]
         @test T.filtermask(startswith(T.col(:b), "x"), missingvals) ==
               [true, false, false]
-        @test T.filtermask(!T.in_(T.col(:a), (1, missing)), missingvals) ==
+        @test T.filtermask(!T.colin(T.col(:a), (1, missing)), missingvals) ==
               [false, false, false]
         @test T.filtermask(T.Cmp(T.OP_NE, T.col(:a), 1), missingvals) ==
               [false, false, true]
@@ -172,7 +191,7 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         indexonly = IndexOnlyTable(IndexOnlyColumn([10, 20, 30, 40]))
         @test T.scan(indexonly, T.Scan(select = :a, offset = 1, limit = 2)).a == [20, 30]
         @test T.filtermask(T.col(:a) > 20, indexonly) == [false, false, true, true]
-        @test T.filtermask(T.in_(T.col(:a), (10, 40)), indexonly) ==
+        @test T.filtermask(T.colin(T.col(:a), (10, 40)), indexonly) ==
               [true, false, false, true]
         indexmissing = IndexOnlyTable(IndexOnlyColumn(Union{Int, Missing}[10, missing, 30]))
         @test T.filtermask(T.isnull(T.col(:a)), indexmissing) == [false, true, false]
@@ -184,12 +203,12 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
 
     @testset "scan: validate=false filters treat unmatched refs as all-missing" begin
         nt2 = (a = [1, 2, 3], b = ["x", "y", "z"])
-        # strict (default): unknown filter refs error, matching bind
+        # strict (default): unknown filter refs error, matching resolve
         @test_throws ArgumentError T.scan(nt2, T.Scan(filter = T.col(:gone) > 1))
         @test_throws ArgumentError T.filtermask(T.col(:gone) > 1, nt2)
         # lenient: comparisons/membership/strings against the absent column
         # evaluate to missing → rows excluded, SQL-style
-        for f in (T.col(:gone) > 1, T.in_(T.col(:gone), (1, 2)),
+        for f in (T.col(:gone) > 1, T.colin(T.col(:gone), (1, 2)),
                   startswith(T.col(:gone), "x"))
             out = T.scan(nt2, T.Scan(filter = f, validate = false))
             @test isempty(out.a)
@@ -206,12 +225,12 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         out = T.scan(nt2, T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) >= 1),
                                    validate = false))
         @test isempty(out.a)
-        # the Scan form of filtermask follows validate; bind still omits the
+        # the Scan form of filtermask follows validate; resolve still omits the
         # unmatched ref from filtercols
         @test T.filtermask(T.Scan(filter = T.isnull(T.col(:gone)), validate = false),
                            nt2) == [true, true, true]
-        b = T.bind(T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) > 1),
-                          validate = false), (:a, :b))
+        b = T.resolve(T.Scan(filter = (T.col(:gone) > 1) & (T.col(:a) > 1),
+                             validate = false), (:a, :b))
         @test b.filtercols == [1]
     end
 
@@ -220,20 +239,20 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         # equality against a vector literal is per-row whole-value equality —
         # never an elementwise broadcast into the rows (which zips silently
         # when lengths happen to match and throws DimensionMismatch when not)
-        out = T.scan(lists, T.Scan(filter = T.coleq(T.col(:l), [1, 2])))
+        out = T.scan(lists, T.Scan(filter = T.colcmp(==, T.col(:l), [1, 2])))
         @test out.n == [10, 30]
-        out = T.scan(lists, T.Scan(filter = T.colne(T.col(:l), [1, 2])))
+        out = T.scan(lists, T.Scan(filter = T.colcmp(!=, T.col(:l), [1, 2])))
         @test out.n == [20]
-        @test T.filtermask(T.in_(T.col(:l), ([[3]], [[1, 2]])), lists) ==
+        @test T.filtermask(T.colin(T.col(:l), ([[3]], [[1, 2]])), lists) ==
               [false, false, false]
-        @test T.filtermask(T.in_(T.col(:l), ([3],)), lists) == [false, true, false]
+        @test T.filtermask(T.colin(T.col(:l), ([3],)), lists) == [false, true, false]
         # a 2-row column against a 2-element literal must still be whole-value
         two = (l = [[1, 2], [5, 6]], n = [1, 2])
-        out = T.scan(two, T.Scan(filter = T.coleq(T.col(:l), [5, 6])))
+        out = T.scan(two, T.Scan(filter = T.colcmp(==, T.col(:l), [5, 6])))
         @test out.n == [2]
         # missing rows keep SQL semantics through whole-value comparison
         lm = (l = Union{Missing, Vector{Int}}[[1], missing, [2]], n = [1, 2, 3])
-        out = T.scan(lm, T.Scan(filter = T.coleq(T.col(:l), [2])))
+        out = T.scan(lm, T.Scan(filter = T.colcmp(==, T.col(:l), [2])))
         @test out.n == [3]
     end
 
@@ -251,8 +270,37 @@ Tables.getcolumn(t::IndexOnlyTable, ::Symbol) = getfield(t, :a)
         @test residual.select === nothing && residual.limit === nothing && residual.filter === s.filter
         pushed = (b = nt.b, a = nt.a)                # what the source materialized (projection done)
         @test isequal(T.scan(pushed, residual).a, [2, 3, 4])   # filter applied generically
-        @test isempty(T.Scan(s; select = nothing, filter = nothing, limit = nothing))
+        @test T._isidentity(T.Scan(s; select = nothing, filter = nothing, limit = nothing))
         @test T.Scan(s; select = (:c,)).select == T.Scan(select = (:c,)).select
+    end
+
+    @testset "zero-column results preserve row counts" begin
+        projected = T.scan(nt, T.Scan(select = ()))
+        @test isempty(T.columnnames(projected))
+        @test T.rowcount(projected) == 5
+        @test DataAPI.nrow(projected) == 5
+        @test length(T.rows(projected)) == 5
+
+        filtered = T.scan(nt, T.Scan(select = (), filter = T.col(:a) > 1))
+        @test T.rowcount(filtered) == 3
+
+        source = ZeroColumnTable(1_000_000)
+        windowed = T.scan(source, T.Scan(offset = 7, limit = 2))
+        @test T.rowcount(windowed) == 2
+        @test_throws ArgumentError T.scan(source, T.Scan(filter = T.isnull(T.col(:gone))))
+        missingmatch = T.scan(source, T.Scan(
+            filter = T.isnull(T.col(:gone)), validate = false, limit = 3,
+        ))
+        @test T.rowcount(missingmatch) == 3
+        missingcmp = T.scan(source, T.Scan(
+            filter = T.colcmp(==, T.col(:gone), 1), validate = false,
+        ))
+        @test T.rowcount(missingcmp) == 0
+        overflowwindow = T.scan(source, T.Scan(offset = typemax(Int), limit = typemax(Int)))
+        @test T.rowcount(overflowwindow) == 0
+
+        T.scan(source, T.Scan(limit = 1))
+        @test @allocated(T.scan(source, T.Scan(limit = 1))) < 100_000
     end
 
     @testset "display" begin


### PR DESCRIPTION
## Summary

Add `Tables.Scan`, a plain-data request for projection, filtering, row bounds, renaming, and output conversion. Add `Tables.scan(table, request)` as the generic reference implementation.

```julia
request = Tables.Scan(
    select = (:id, :price => Float64 => :amount),
    filter = Tables.colcmp(==, Tables.col(:status), "active") &
             (Tables.col(:price) >= 10),
    limit = 100,
)

result = Tables.scan(table, request)
```

A Scan is a logical request. It does not require a physical full-table scan. A source can use indexes, statistics, partition pruning, or other exact optimizations while it reads data. It can then reject unsupported work or pass an unconsumed residual Scan to the generic executor. There is no capability-negotiation, `apply`, or `finish` protocol.

## Consumer semantics

- Requests and expression trees contain plain data. They do not store callbacks.
- The operation order is filter, offset/limit, then projection/rename/type conversion.
- Filters use source column names before rename.
- A filter keeps only rows whose result is exactly `true`; `missing` is excluded, like SQL `WHERE`.
- `select=Tables.All()` is the projection identity and the default.
- `select=()` selects zero columns.
- Selection order defines output order.
- `validate=false` drops unmatched selections and treats unmatched filter columns as all-`missing`.
- An identity request returns the input table unchanged.
- Zero-column results preserve their row count.

Selection supports names, indices, regular expressions, `DataAPI.All()` as `Tables.All()`, `Tables.Not(...)`, output renames, and type overrides.

Filters support `Tables.colcmp`, ordered comparison shorthand, `Tables.colin`, `Tables.isnull`, string predicates, Boolean composition, and source-specific `OpNode` extensions. Comparison and string operation codes use enums.

`Tables.isnull` is deliberate. Adding `Base.ismissing(::Tables.Col)` would specialize Base's broad fallback and invalidate unrelated compiled code when Tables loads. Equality uses `Tables.colcmp(==, ...)`, so expression construction does not change Base equality contracts.

## Source helpers

- `Tables.resolve` resolves and validates a request against source column names.
- The resolved filter normalizes positional references to source names.
- `Tables.filtermask(::BoundScan, table)` can evaluate against predicate-only columns while preserving `validate=false` behavior.
- `Tables.Scan(existing; ...)` builds a residual after a source consumes supported axes.
- `Tables.describe` displays an original request and its residual.
- A source-specific `OpNode` must be consumed before generic resolution.

The manual now separates the consumer API from the source implementation API and documents pushdown, residual, and missing-value semantics.

All APIs remain namespaced under `Tables`. The minimum Julia version is 1.9.

## Review hardening

The review pass also:

- uses `Tables.All()` as the projection identity and `()` as the zero-column selection;
- imports the shared `DataAPI.All` selector;
- replaces the public `isempty(::Scan)` overload with an internal identity check;
- centralizes selector lookup and improves reference errors;
- adds an explicit `@noinline` mask function barrier;
- uses `Tables.allocatecolumn` for output conversion;
- resolves positional filters before predicate-only materialization;
- preserves row counts for empty projections and zero-column sources without row-sized allocation.

## Local validation

- Full Tables.jl suite passes on Julia 1.9 and Julia 1.12.
- The focused Scan suite passes 156 tests on each version.
- Documentation builds successfully.
- `Test.detect_ambiguities(Tables; recursive=true)` reports no ambiguities.
- CSV rewrite Scan tests pass 307 tests on Julia 1.10 and Julia 1.12 after the mechanical API update.
- Arrow rewrite passes 342 facade tests and every acceptance battery on Julia 1.10 and Julia 1.12 after the mechanical API update.
- CI covers minimum, stable, nightly, 32-bit Windows, documentation, and invalidation checks.

Implementation prepared with Claude Code.

Co-authored by Codex