### PR TITLE
Address post-merge Tables.Scan review feedback

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tables"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.14.0"
+version = "1.14.1"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/docs/src/implementing-the-interface.md
+++ b/docs/src/implementing-the-interface.md
@@ -26,6 +26,9 @@ or `Tables.AbstractColumns` object satisfies the respective interface.
 
 As an additional source of documentation, see [this discourse post](https://discourse.julialang.org/t/struggling-to-implement-tables-jl-interface-for-vector-mystruct/42318/7?u=quinnj) outlining in detail a walk-through of making a row-oriented table.
 
+Sources that can push down column selection, filtering, or row limits can also
+support `Tables.Scan`. See [Scan Source Implementations](scan.md#Source-Implementations).
+
 ## `Tables.AbstractRow`
 
 ```@docs; canonical = false

--- a/docs/src/scan.md
+++ b/docs/src/scan.md
@@ -82,9 +82,10 @@ Selection order defines output order. Duplicate output names are an error.
 - `startswith`, `endswith`, and `contains` for strings.
 - `&`, `|`, and `!` for Boolean composition.
 
-Expression nodes contain plain data. They do not store callbacks. This makes a
-request inspectable and suitable for serialization, pushdown, and static
-compilation.
+Built-in expression nodes represent operations as data instead of storing
+predicate callbacks. Literal values and source-specific `OpNode` arguments are
+caller-defined; keep them plain and serializable when requests must cross a
+process or persistence boundary.
 
 Only ordered comparisons have direct operator shorthand. Equality uses
 `Tables.colcmp(==, column, value)` because `==` on expression objects retains
@@ -159,7 +160,8 @@ leaving only projection). Two constraints follow from the ordering:
   well.
 - Column selection may be removed from the residual (`select=Tables.All()`)
   only when no residual filter references a column that the source dropped or
-  renamed. A residual filter still uses source column names.
+  renamed, or whose type or comparison behavior the source changed. A residual
+  filter must still observe the original source names and values.
 
 Only remove work that the source performed exactly.
 

--- a/docs/src/scan.md
+++ b/docs/src/scan.md
@@ -1,8 +1,10 @@
 # Scan Requests
 
-`Tables.Scan` is a logical request for projection, filtering, row bounds, and
-output conversion. It does not require a physical full-table scan. A source can
-use an index, statistics, partition pruning, or any other exact optimization.
+`Tables.Scan` describes which columns and rows a table source should return. It
+can select and rename columns, set output column types, filter rows, and apply
+an `offset` or `limit`. It does not require a physical full-table scan. A source
+can use an index, statistics, partition pruning, or any other exact
+optimization.
 
 The API has two roles:
 
@@ -12,6 +14,14 @@ The API has two roles:
   request while they read data.
 
 ## Consumer API
+
+The main constructor keywords are:
+
+- `select`: select, rename, or set the output type of columns.
+- `filter`: keep rows that match a plain-data expression.
+- `offset`: skip matching rows before producing output.
+- `limit`: set the maximum number of output rows.
+- `validate`: control how references to absent columns are handled.
 
 ```@example scan
 using Tables
@@ -76,6 +86,10 @@ Expression nodes contain plain data. They do not store callbacks. This makes a
 request inspectable and suitable for serialization, pushdown, and static
 compilation.
 
+Only ordered comparisons have direct operator shorthand. Equality uses
+`Tables.colcmp(==, column, value)` because `==` on expression objects retains
+its normal Boolean meaning.
+
 ### Missing values
 
 Filter evaluation uses SQL-like three-valued logic:
@@ -86,8 +100,10 @@ Filter evaluation uses SQL-like three-valued logic:
 - `&`, `|`, and `!` propagate `missing` with three-valued Boolean rules.
 - The top-level filter keeps a row only when its result is exactly `true`.
 
-These lifting rules are deliberate. Julia functions other than comparison
-operators do not generally lift `missing` on their own.
+Comparison operators follow Julia's `missing` propagation. Scan also guarantees
+that membership and string predicates return `missing` for missing column
+values. This can differ from Julia's `in` for containers that match `missing`
+directly.
 
 The name `Tables.isnull` also avoids defining `Base.ismissing(::Tables.Col)`.
 Such a method would specialize a broad Base fallback and can invalidate
@@ -122,13 +138,14 @@ bound = Tables.resolve(request, source_names)
 mask = Tables.filtermask(bound, predicate_columns)
 ```
 
-If a source consumes an axis, it removes that axis from the residual. The
-axes compose in a fixed order — filter, then row bounds, then projection —
-so an axis can only be removed together with every axis that executes before
-it. A source that evaluated the filter itself (for example with
-`Tables.filtermask`) hands the rest to the generic executor:
+If a source performs an operation, it removes that operation from the residual.
+The operations run in a fixed order: filter, then `offset`/`limit`, then column
+selection and conversion. An operation can only be removed together with every
+operation that runs before it. A source that evaluated the filter itself, for
+example with `Tables.filtermask`, hands the rest to the generic executor:
 
 ```julia
+filtered_columns = ... # columns containing only rows selected by the filter
 residual = Tables.Scan(request; filter=nothing)
 result = Tables.scan(filtered_columns, residual)
 ```
@@ -140,19 +157,20 @@ leaving only projection). Two constraints follow from the ordering:
 - `limit`/`offset` count qualifying rows, after the filter. A source that
   cannot consume the filter must leave the row bounds in the residual as
   well.
-- Projection may be stripped (`select=Tables.All()`, the projection identity)
-  only when no residual filter references a column the projection dropped or
-  renamed — the residual filter still uses source column names.
+- Column selection may be removed from the residual (`select=Tables.All()`)
+  only when no residual filter references a column that the source dropped or
+  renamed. A residual filter still uses source column names.
 
 Only remove work that the source performed exactly.
 
 A statistics check that only prunes impossible partitions does not consume the
 filter.
 
-`Tables.OpNode(name, args)` is the extension point for source-specific,
-plain-data operations. A source can recognize and consume a named operation
-before it calls `Tables.resolve`. Resolution and the generic executor reject an
-unconsumed `OpNode`.
+`Tables.OpNode(name, args)` represents a source-specific filter operation using
+plain data. For example, a geospatial source can define a named bounding-box
+operation and translate it to its native query. The source must consume that
+node before it calls `Tables.resolve`. Resolution and the generic executor
+reject an unconsumed `OpNode` because they do not know its meaning.
 
 Zero-column results retain their row count. Sources should preserve the same
 property when they return a fully pushed result.

--- a/docs/src/using-the-interface.md
+++ b/docs/src/using-the-interface.md
@@ -2,6 +2,9 @@
 
 We start by discussing _usage_ of the Tables.jl interface functions, since that can help contextualize _implementing_ them for custom table types.
 
+To select columns, filter rows, or apply row limits through a shared request,
+see the consumer section of [Scan Requests](scan.md#Consumer-API).
+
 At a high level, Tables.jl provides two powerful APIs for predictably accessing data from any table-like source:
 ```julia
 # access data of input table `x` row-by-row

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -9,6 +9,7 @@ if !hasmethod(getproperty, Tuple{Tuple, Int})
 end
 
 import Base: ==
+import DataAPI: All
 
 """
     Tables.AbstractColumns

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -31,8 +31,6 @@
 
 # --- column references & selection items --------------------------------------
 
-import DataAPI: All
-
 """
     Tables.Not(ref)
 
@@ -94,12 +92,14 @@ abstract type ScanExpr end
 struct Col <: ScanExpr
     ref::Union{Symbol, String, Int}
 end
+
 """
     Tables.col(ref)
 
-A column reference inside a `Scan` filter: `col(:price) > 100`. Comparisons
-against literals, `colin`, `isnull`, `startswith`/`endswith`/`contains`, and
-`&`/`|`/`!` build plain expression values.
+A column reference inside a [`Scan`](@ref) filter: for example,
+`col(:price) > 100`. Comparisons against literals, [`colin`](@ref),
+[`isnull`](@ref), `startswith`/`endswith`/`contains`, and `&`/`|`/`!` build
+plain expression values.
 """
 col(r::Union{Symbol, AbstractString, Int}) = Col(r isa AbstractString ? String(r) : r)
 
@@ -124,6 +124,7 @@ struct Cmp{T} <: ScanExpr
         return new{T}(op, lhs, rhs)
     end
 end
+# Accept validated integer codes when reconstructing plain-data expressions.
 function Cmp(op::Integer, lhs::Col, rhs)
     0x01 <= op <= 0x06 || throw(ArgumentError("unknown comparison operator code $op"))
     return Cmp(ComparisonOperator(op), lhs, rhs)
@@ -138,15 +139,16 @@ _comparisonoperator(::typeof(>=)) = OP_GE
 _comparisonoperator(op) = throw(ArgumentError(
     "unsupported comparison function $(repr(op)); expected ==, !=, <, <=, >, or >=",
 ))
+
 """
     Tables.colcmp(op, col, value)
 
-Build a comparison predicate for a column and a literal value. `op` must be
-`==`, `!=`, `<`, `<=`, `>`, or `>=`. Ordered comparisons also support the
-shorthand `col(:x) < value` for numeric, string, and character values.
+Build a comparison predicate for a column and a literal value to be used inside
+a [`Scan`](@ref) filter. `op` must be `==`, `!=`, `<`, `<=`, `>`, or `>=`.
 
-Use `colcmp` for equality so `==` and `isequal` on expression objects keep
-their normal Boolean contracts.
+Ordered comparisons can also use operators directly, such as
+`col(:x) < value`, for numeric, string, and character values. Equality must use
+`colcmp` because `==` and `isequal` on expression objects return a `Bool`.
 """
 colcmp(op, c::Col, value) = Cmp(_comparisonoperator(op), c, value)
 
@@ -162,8 +164,10 @@ end
 """
     Tables.colin(col, values)
 
-Build a membership predicate: `colin(col(:status), ("active", "trial"))`.
-If the column value is `missing`, the predicate result is also `missing`.
+Build a membership predicate to be used inside a [`Scan`](@ref) filter: for
+example, `colin(col(:status), ("active", "trial"))`. If the column value is
+`missing`, the predicate result is also `missing`, even when the values
+container could otherwise match `missing`.
 """
 colin(c::Col, values) = In(c, values)
 
@@ -200,6 +204,7 @@ struct StrPred <: ScanExpr
         return new(kind, lhs, String(s))
     end
 end
+# Accept validated integer codes when reconstructing plain-data expressions.
 function StrPred(kind::Integer, lhs::Col, s::AbstractString)
     0x01 <= kind <= 0x03 || throw(ArgumentError("unknown string predicate code $kind"))
     return StrPred(StringPredicate(kind), lhs, s)
@@ -220,10 +225,10 @@ struct AlwaysFalse <: ScanExpr end
 """
     Tables.OpNode(name, args)
 
-The expression algebra's growth channel. Every node has a symbolic `name` and
-plain-data arguments. A source can recognize and consume that name before
-generic resolution. An unconsumed `OpNode` is rejected by `Tables.resolve` and
-the generic executor.
+A source-specific, plain-data filter operation. A source can recognize `name`,
+interpret `args`, and remove the operation before calling [`resolve`](@ref).
+The generic executor cannot interpret source-specific operations and rejects an
+unconsumed `OpNode`.
 """
 struct OpNode <: ScanExpr
     name::Symbol
@@ -369,8 +374,8 @@ _isidentity(s::Scan) =
 """
     Tables.BoundColumn
 
-One output column after `Tables.resolve`: the source column index, the output
-name (post-rename, uniqueness enforced), and the optional type override.
+One output column after [`resolve`](@ref): the source column index, the output
+name after renaming, and the optional type override. Output names are unique.
 """
 struct BoundColumn
     index::Int
@@ -381,7 +386,7 @@ end
 """
     Tables.BoundScan
 
-A `Scan` resolved against a concrete schema: output columns in order, the
+A [`Scan`](@ref) resolved against a concrete schema: output columns in order, the
 filter with positional references normalized to source names, the source
 column indices it references, and the row bounds. Sources can use this after
 resolving a raw `Scan`.
@@ -460,7 +465,8 @@ end
 """
     Tables.resolve(scan::Scan, names) -> BoundScan
 
-Resolve a `Scan` against a source's column names (any iterable of `Symbol`s).
+Resolve a [`Scan`](@ref) against a source's column names (any iterable of
+`Symbol`s).
 Errors on unmatched references (under `validate`), mixed `Not`/positive
 selections, and duplicate output names. Regex references expand in file
 order; selection order defines output order. Positional filter references are
@@ -580,12 +586,13 @@ end
 """
     Tables.filtermask(scan_or_expr, table) -> AbstractVector{Bool}
 
-Evaluate a scan's filter over a table's columns: `mask[i]` is `true` iff row
-`i` qualifies (a `missing` predicate result excludes the row). Sources use
-this for their own pushdown implementations. The bare-expression form is
-strict about unknown column references. The `Scan` form follows the scan's
-`validate` setting. The `BoundScan` form uses its resolved filter and is safe
-to evaluate over a table containing only `filtercols`.
+Evaluate a [`Scan`](@ref)'s filter over a table's columns. `mask[i]` is `true`
+if and only if row `i` qualifies. A `missing` predicate result excludes the
+row. Sources use this for their own pushdown implementations. The
+bare-expression form is strict about unknown column references. The `Scan`
+form follows the scan's `validate` setting. The `BoundScan` form uses its
+resolved filter and is safe to evaluate over a table containing only
+`filtercols`.
 """
 filtermask(e::ScanExpr, table) = _boolmask(_evalexpr(_checkpredicate(e), columns(table)))
 filtermask(s::Scan, table) = s.filter === nothing ?
@@ -605,10 +612,7 @@ function _converted(::Type{T}, c::AbstractVector) where {T}
     anymissing = any(ismissing, c)
     E = anymissing ? Union{T, Missing} : T
     out = allocatecolumn(E, length(c))
-    @inbounds for i in eachindex(c)
-        x = c[i]
-        out[i] = ismissing(x) ? missing : convert(T, x)
-    end
+    copyto!(out, c)
     return out
 end
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -226,10 +226,11 @@ struct AlwaysFalse <: ScanExpr end
 """
     Tables.OpNode(name, args)
 
-A source-specific, plain-data filter operation. A source can recognize `name`,
-interpret `args`, and remove the operation before calling [`resolve`](@ref).
-The generic executor cannot interpret source-specific operations and rejects an
-unconsumed `OpNode`.
+A source-specific filter operation. A source can recognize `name`, interpret
+the source-defined `args`, and remove the operation before calling
+[`resolve`](@ref). Keep arguments plain and serializable when requests must
+cross a process or persistence boundary. The generic executor cannot interpret
+source-specific operations and rejects an unconsumed `OpNode`.
 """
 struct OpNode <: ScanExpr
     name::Symbol

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -47,9 +47,9 @@ const ColRef = Union{Symbol, String, Int, Regex}
 """
     Tables.SelectItem
 
-One resolved element of `Scan.select`: a column reference plus optional type
-override and output name. Users never construct these directly — the `Scan`
-constructor lowers `ref`, `ref => name`, `ref => Type`, and
+One resolved element of a [`Scan`](@ref)'s `select` field: a column reference
+plus optional type override and output name. Users never construct these
+directly. The `Scan` constructor lowers `ref`, `ref => name`, `ref => Type`, and
 `ref => Type => name` forms.
 """
 struct SelectItem
@@ -179,8 +179,9 @@ end
 """
     Tables.isnull(col)
 
-Build a predicate that is true when the column value is Julia's `missing`.
-Use `!Tables.isnull(col)` to match values that are not `missing`.
+Build a predicate for a [`Scan`](@ref) filter that is true when the column value
+is Julia's `missing`. Use `!Tables.isnull(col)` to match values that are not
+`missing`.
 
 The `isnull` name is deliberate. Defining `Base.ismissing(::Col)` would
 specialize Base's broad fallback and invalidate unrelated precompiled code

--- a/test/scan.jl
+++ b/test/scan.jl
@@ -4,6 +4,20 @@ end
 Base.length(c::IndexOnlyColumn) = length(c.data)
 Base.getindex(c::IndexOnlyColumn, i::Int) = c.data[i]
 
+struct CopyAwareColumn <: AbstractVector{Int}
+    data::Vector{Int}
+    copied::Base.RefValue{Bool}
+end
+Base.size(c::CopyAwareColumn) = size(c.data)
+Base.getindex(c::CopyAwareColumn, i::Int) = c.data[i]
+function Base.copyto!(dest::Vector{Float64}, src::CopyAwareColumn)
+    src.copied[] = true
+    @inbounds for i in eachindex(src)
+        dest[i] = src[i]
+    end
+    return dest
+end
+
 struct IndexOnlyTable{T} <: Tables.AbstractColumns
     a::IndexOnlyColumn{T}
 end
@@ -147,6 +161,15 @@ Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
         @test out.b == ["yy", "zzz"]
         missingvals = (a = Union{Int, Missing}[1, missing, 3],
                        b = Union{String, Missing}["x", missing, "z"])
+        missingcols = T.columns(missingvals)
+        @test isequal(
+            T._evalexpr(T.colcmp(==, T.col(:a), 1), missingcols),
+            Union{Bool, Missing}[true, missing, false],
+        )
+        @test isequal(
+            T._evalexpr(T.colin(T.col(:a), (1, 2)), missingcols),
+            Union{Bool, Missing}[true, missing, false],
+        )
         @test T.filtermask(T.colin(T.col(:a), (1, missing)), missingvals) ==
               [true, false, false]
         @test T.filtermask(T.colin(T.col(:a), (2, missing)), missingvals) ==
@@ -191,6 +214,10 @@ Tables.rowcount(t::ZeroColumnTable) = getfield(t, :nrows)
         @test eltype(out.a) == Union{Float64, Missing}
         converted = Union{Float64, Missing}[1.0, missing]
         @test T._converted(Float64, converted) === converted
+        copied = Ref(false)
+        copyaware = CopyAwareColumn([1, 2, 3], copied)
+        @test T._converted(Float64, copyaware) == [1.0, 2.0, 3.0]
+        @test copied[]
         @test_throws InexactError T.scan((a = [1.5],), T.Scan(select = (:a => Int,)))
         indexonly = IndexOnlyTable(IndexOnlyColumn([10, 20, 30, 40]))
         @test T.scan(indexonly, T.Scan(select = :a, offset = 1, limit = 2)).a == [20, 30]


### PR DESCRIPTION
## Summary

- route output conversion through `copyto!` so specialized column types can use optimized copying
- directly test that comparison and membership expressions preserve `missing` before mask lowering
- clarify the consumer and source documentation, including equality syntax, residual operations, and `OpNode` behavior
- centralize the `DataAPI.All` import and bump the patch version to 1.14.1

This follows up on Milan's late review of #380 while keeping the released Tables.Scan API unchanged.

## Validation

- `julia +1.9 --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`
- `julia +1.12 --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`
- `julia +1.12 --project=docs -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'`

Co-authored by Codex