### PR TITLE
Update setup-julia to v3

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.base_ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
-    - uses: julia-actions/setup-julia@v2
+    - uses: julia-actions/setup-julia@v3
       with:
         version: '1'
     - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'min'  # Oldest supported version
+          - 'min-patch'  # Oldest supported version
           - '1'    # Latest release
           - 'nightly'
         os:
@@ -25,7 +25,7 @@ jobs:
             arch: x86
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
## Summary

- update `julia-actions/setup-julia` from v2 to v3
- use `min-patch` so CI still tests the oldest supported Julia patch

This supersedes #378, whose `version: min` would select the latest patch of the minimum minor under setup-julia v3.

## Validation

- workflow files pass `actionlint`
- PR CI will validate the updated action on every matrix job

Co-authored by Codex