### PR TITLE
Avoid inferring table columns from array internals

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -213,7 +213,7 @@ end
             WT = wrappedtype(eltype(rowitr))
             if WT <: Tuple
                 return allocatecolumns(Schema((Symbol("Column$i") for i = 1:fieldcount(WT)), _fieldtypes(WT)), 0)
-            elseif isconcretetype(WT) && fieldcount(WT) > 0
+            elseif !(WT <: AbstractArray) && isconcretetype(WT) && fieldcount(WT) > 0
                 return allocatecolumns(Schema(fieldnames(WT), _fieldtypes(WT)), 0)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -488,6 +488,11 @@ Base.propertynames(g::GenericTable) = (:a, :b, :c)
     t = Tables.columns(rows)
     @test Tables.schema(t) == Tables.Schema((:Column1, :Column2, :Column3), (Int64, Float64, String))
 
+    # Array fields are implementation details, not table columns (#353).
+    @test Tables.columntable(Vector{Any}[]) === NamedTuple()
+    @test Tables.columntable(typeof(view(Any[], :))[]) === NamedTuple()
+    @test Tables.columntable(Matrix{Any}[]) === NamedTuple()
+
     # 311
     gt = GenericTable()
     @test Tables.schema(gt) == Tables.Schema((:a, :b, :c), (Int, Float64, String))


### PR DESCRIPTION
## Summary

- treat empty iterators of `AbstractArray` rows as schema-less
- preserve empty tuple and struct row inference
- cover vector, view, and matrix element types

Fixes #353. This supersedes the narrower special cases in #355.

## Validation

- full test suite on Julia 1.9
- full test suite on Julia 1.12

Co-authored by Codex