### PR TITLE
Fix the MatrixTable row interface example

### DIFF
--- a/docs/src/implementing-the-interface.md
+++ b/docs/src/implementing-the-interface.md
@@ -159,7 +159,8 @@ mattbl = Tables.table(mat)
 @test Tables.istable(typeof(mattbl))
 # test that it defines row access
 @test Tables.rowaccess(typeof(mattbl))
-@test Tables.rows(mattbl) === mattbl
+matrows = Tables.rows(mattbl)
+@test Tables.rows(matrows) === matrows
 # test that it defines column access
 @test Tables.columnaccess(typeof(mattbl))
 @test Tables.columns(mattbl) === mattbl
@@ -169,9 +170,9 @@ mattbl = Tables.table(mat)
 @test Tables.getcolumn(mattbl, :Column1) == [1,2,3]
 @test Tables.getcolumn(mattbl, 1) == [1,2,3]
 @test Tables.columnnames(mattbl) == [:Column1, :Column2, :Column3]
-# now let's iterate our MatrixTable to get our first MatrixRow
-matrow = first(mattbl)
-@test eltype(mattbl) == typeof(matrow)
+# now let's iterate our MatrixRowTable to get our first MatrixRow
+matrow = first(matrows)
+@test eltype(matrows) == typeof(matrow)
 # now we can test our `Tables.AbstractRow` interface methods on our MatrixRow
 @test matrow.Column1 == 1
 @test Tables.getcolumn(matrow, :Column1) == 1


### PR DESCRIPTION
## Summary

- test row access through the returned `MatrixRowTable`
- iterate the row table instead of the column-oriented `MatrixTable`

Fixes #270.

## Validation

- Documenter build and doctests pass on Julia 1.12

Co-authored by Codex